### PR TITLE
add `io_uring_wait_for_events` support

### DIFF
--- a/ext/event/backend/uring.c
+++ b/ext/event/backend/uring.c
@@ -573,4 +573,5 @@ static int io_uring_wait_for_events(struct io_uring *ring, struct io_uring_cqe *
 	
 	// It should return current pending events.
 	ret = __io_uring_get_cqe_with_availables(ring, cqe_ptr, to_submit, 1, NULL, nr_available);
+	return ret;
 }


### PR DESCRIPTION
## Description

This patch trying to expose the `available_nr` from internal APIs of `liburing` to make the API easier to be handled.

## TODO

- [x] Impl of internal API changes
- [ ] Integrate with current uring backend
- [ ] Pass existing tests
- [ ] Check robustness on heavy load (especially if SQE is full)
- [ ] Prepare a version that may be merged to `liburing` library