### PR TITLE
fix JRuby syntax error

### DIFF
--- a/lib/event/selector.rb
+++ b/lib/event/selector.rb
@@ -47,8 +47,8 @@ module Event
 			end
 		end
 		
-		def self.new(...)
-			default.new(...)
+		def self.new(*args)
+			default.new(*args)
 		end
 	end
 end


### PR DESCRIPTION
## Description

JRuby (2.8-compatible syntax) doesn't support the `...` syntax properly

### Types of Changes

- Use `*args` instead of `...` to avoid syntax errors
- `select` still causes halting in JRuby CI

### Testing

- [x] I tested my changes locally.
