### PR TITLE
Ensure WNOHANG is available on BSD.

### DIFF
--- a/ext/io/event/selector/selector.c
+++ b/ext/io/event/selector/selector.c
@@ -21,6 +21,11 @@
 #include "selector.h"
 #include <fcntl.h>
 
+#ifndef HAVE_RB_PROCESS_STATUS_WAIT
+// Pull in WNOHANG.
+#include <sys/wait.h>
+#endif
+
 static const int DEBUG = 0;
 
 static ID id_transfer, id_alive_p;

--- a/lib/io/event/version.rb
+++ b/lib/io/event/version.rb
@@ -19,5 +19,5 @@
 # THE SOFTWARE.
 
 module IO::Event
-	VERSION = "1.0.1"
+	VERSION = "1.0.2"
 end


### PR DESCRIPTION
## Description

Fix https://github.com/socketry/io-event/issues/24 by pulling in `sys/wait.h`.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.