### PR TITLE
Yield when waiting on IO would otherwise fail.

### DIFF
--- a/test/io/event/selector/file_io.rb
+++ b/test/io/event/selector/file_io.rb
@@ -44,6 +44,18 @@ FileIO = Sus::Shared("file io") do
 			writer.transfer
 			reader.transfer
 		end
+		
+		it "can wait for the file to become writable" do
+			writer = Fiber.new do
+				expect(
+					selector.io_wait(Fiber.current, file, IO::WRITABLE)
+				).to be == IO::WRITABLE
+			end
+			
+			writer.transfer
+			
+			selector.select(0)
+		end
 	end
 end
 


### PR DESCRIPTION
## Description

It turns out in some cases `write` can return `EAGAIN` even if it can't be added to epoll. In this case, yield to the event loop.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
