### PR TITLE
Small cleanup

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,0 @@
---require spec_helper

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -171,7 +171,6 @@ VALUE IO_Event_Selector_URing_raise(int argc, VALUE *argv, VALUE self)
 	return IO_Event_Selector_raise(&data->backend, argc, argv);
 }
 	
-	int blocked;
 VALUE IO_Event_Selector_URing_ready_p(VALUE self) {
 	struct IO_Event_Selector_URing *data = NULL;
 	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, data);


### PR DESCRIPTION
This PR removes unused `.rspec` file and one obsolete line of code in `uring.c`.

### Types of Changes

- Maintenance.

### Testing

Existing specs should cover these changes.