### PR TITLE
Use EPOLLEXCLUSIVE by default.

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -98,7 +98,7 @@ void IO_Event_Interrupt_add(struct IO_Event_Interrupt *interrupt, struct IO_Even
 	int descriptor = IO_Event_Interrupt_descriptor(interrupt);
 	
 	struct epoll_event event = {
-		.events = EPOLLIN|EPOLLRDHUP,
+		.events = EPOLLIN|EPOLLHUP|EPOLLEXCLUSIVE,
 		.data = {.ptr = NULL},
 	};
 	
@@ -266,8 +266,7 @@ uint32_t epoll_flags_from_events(int events) {
 	flags |= EPOLLHUP;
 	flags |= EPOLLERR;
 	
-	// Immediately remove this descriptor after reading one event:
-	flags |= EPOLLONESHOT;
+	flags |= EPOLLEXCLUSIVE;
 	
 	if (DEBUG) fprintf(stderr, "epoll_flags_from_events events=%d flags=%d\n", events, flags);
 	


### PR DESCRIPTION
In multi-threaded/multi-process servers, this should improve connect performance.

### Types of Changes

- Performance improvement.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
