### PR TITLE
Expose `nonblock` set/restore methods + compatible pure Ruby implementation

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -715,9 +715,11 @@ void Init_IO_Event_Selector_EPoll(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_EPoll, "close", IO_Event_Selector_EPoll_close, 0);
 	
 	rb_define_method(IO_Event_Selector_EPoll, "io_wait", IO_Event_Selector_EPoll_io_wait, 3);
-
+	
+#ifdef HAVE_RUBY_IO_BUFFER_H
 	rb_define_method(IO_Event_Selector_EPoll, "io_read", IO_Event_Selector_EPoll_io_read_compatible, -1);
 	rb_define_method(IO_Event_Selector_EPoll, "io_write", IO_Event_Selector_EPoll_io_write_compatible, -1);
+#endif
 	
 	// Once compatibility isn't a concern, we can do this:
 	// rb_define_method(IO_Event_Selector_EPoll, "io_read", IO_Event_Selector_EPoll_io_read, 5);

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -764,9 +764,11 @@ void Init_IO_Event_Selector_KQueue(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_KQueue, "close", IO_Event_Selector_KQueue_close, 0);
 	
 	rb_define_method(IO_Event_Selector_KQueue, "io_wait", IO_Event_Selector_KQueue_io_wait, 3);
-
+	
+#ifdef HAVE_RUBY_IO_BUFFER_H
 	rb_define_method(IO_Event_Selector_KQueue, "io_read", IO_Event_Selector_KQueue_io_read_compatible, -1);
 	rb_define_method(IO_Event_Selector_KQueue, "io_write", IO_Event_Selector_KQueue_io_write_compatible, -1);
+#endif
 	
 	rb_define_method(IO_Event_Selector_KQueue, "process_wait", IO_Event_Selector_KQueue_process_wait, 3);
 }

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -737,9 +737,11 @@ void Init_IO_Event_Selector_URing(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_URing, "close", IO_Event_Selector_URing_close, 0);
 	
 	rb_define_method(IO_Event_Selector_URing, "io_wait", IO_Event_Selector_URing_io_wait, 3);
-
+	
+#ifdef HAVE_RUBY_IO_BUFFER_H
 	rb_define_method(IO_Event_Selector_URing, "io_read", IO_Event_Selector_URing_io_read_compatible, -1);
 	rb_define_method(IO_Event_Selector_URing, "io_write", IO_Event_Selector_URing_io_write_compatible, -1);
+#endif
 	
 	rb_define_method(IO_Event_Selector_URing, "io_close", IO_Event_Selector_URing_io_close, 1);
 	

--- a/fixtures/unix_socket.rb
+++ b/fixtures/unix_socket.rb
@@ -1,0 +1,7 @@
+unless Object.const_defined?(:UNIXSocket)
+	class UNIXSocket
+		def self.pair(&block)
+			Socket.pair(:INET, :STREAM, 0, &block)
+		end
+	end
+end

--- a/lib/io/event.rb
+++ b/lib/io/event.rb
@@ -10,5 +10,5 @@ begin
 	require 'IO_Event'
 rescue LoadError => error
 	warn "Could not load native event selector: #{error}"
-	# Ignore.
+	require_relative 'event/selector/nonblock'
 end

--- a/lib/io/event/selector/nonblock.rb
+++ b/lib/io/event/selector/nonblock.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2022, by Samuel Williams.
+
+require 'io/nonblock'
+
+module IO::Event
+	module Selector
+		def self.nonblock(io, &block)
+			io.nonblock(&block)
+		end
+	end
+end

--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -208,13 +208,13 @@ module IO::Event
 							if length > 0
 								self.io_wait(fiber, io, IO::READABLE)
 							else
-								return -EWOULDBLOCK
+								return EWOULDBLOCK
 							end
 						when :wait_writable
 							if length > 0
 								self.io_wait(fiber, io, IO::WRITABLE)
 							else
-								return -EWOULDBLOCK
+								return EWOULDBLOCK
 							end
 						when nil
 							break
@@ -245,13 +245,13 @@ module IO::Event
 							if length > 0
 								self.io_wait(fiber, io, IO::READABLE)
 							else
-								return -EWOULDBLOCK
+								return EWOULDBLOCK
 							end
 						when :wait_writable
 							if length > 0
 								self.io_wait(fiber, io, IO::WRITABLE)
 							else
-								return -EWOULDBLOCK
+								return EWOULDBLOCK
 							end
 						else
 							total += result

--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -6,8 +6,6 @@
 require_relative '../interrupt'
 require_relative '../support'
 
-require 'io/nonblock'
-
 module IO::Event
 	module Selector
 		class Select
@@ -136,29 +134,35 @@ module IO::Event
 				waiter&.invalidate
 			end
 			
+			EAGAIN = -Errno::EAGAIN::Errno
+			EWOULDBLOCK = -Errno::EWOULDBLOCK::Errno
+			
+			def again?(errno)
+				errno == EAGAIN or errno == EWOULDBLOCK
+			end
+			
 			if Support.fiber_scheduler_v2?
-				EAGAIN = Errno::EAGAIN::Errno
-				
 				def io_read(fiber, io, buffer, length, offset = 0)
 					total = 0
-					io.nonblock = true
 					
-					while true
-						maximum_size = buffer.size - offset
-						result = Fiber.blocking{buffer.read(io, maximum_size, offset)}
-						
-						if result == -EAGAIN
-							if length > 0
-								self.io_wait(fiber, io, IO::READABLE)
-							else
+					Selector.nonblock(io) do
+						while true
+							maximum_size = buffer.size - offset
+							result = Fiber.blocking{buffer.read(io, maximum_size, offset)}
+							
+							if again?(result)
+								if length > 0
+									self.io_wait(fiber, io, IO::READABLE)
+								else
+									return result
+								end
+							elsif result < 0
 								return result
+							else
+								total += result
+								offset += result
+								break if total >= length
 							end
-						elsif result < 0
-							return result
-						else
-							total += result
-							offset += result
-							break if total >= length
 						end
 					end
 					
@@ -167,34 +171,34 @@ module IO::Event
 				
 				def io_write(fiber, io, buffer, length, offset = 0)
 					total = 0
-					io.nonblock = true
 					
-					while true
-						maximum_size = buffer.size - offset
-						result = Fiber.blocking{buffer.write(io, maximum_size, offset)}
-						
-						if result == -EAGAIN
-							if length > 0
-								self.io_wait(fiber, io, IO::READABLE)
-							else
+					Selector.nonblock(io) do
+						while true
+							maximum_size = buffer.size - offset
+							result = Fiber.blocking{buffer.write(io, maximum_size, offset)}
+							
+							if again?(result)
+								if length > 0
+									self.io_wait(fiber, io, IO::READABLE)
+								else
+									return result
+								end
+							elsif result < 0
 								return result
+							else
+								total += result
+								offset += result
+								break if total >= length
 							end
-						elsif result < 0
-							return result
-						else
-							total += result
-							offset += result
-							break if total >= length
 						end
 					end
 					
-					return offset
+					return total
 				end
 			elsif Support.fiber_scheduler_v1?
-				EAGAIN = Errno::EAGAIN::Errno
-				
 				def io_read(fiber, _io, buffer, length, offset = 0)
 					io = IO.for_fd(_io.fileno, autoclose: false)
+					total = 0
 					
 					while true
 						maximum_size = buffer.size - offset
@@ -204,13 +208,13 @@ module IO::Event
 							if length > 0
 								self.io_wait(fiber, io, IO::READABLE)
 							else
-								return -EAGAIN
+								return -EWOULDBLOCK
 							end
 						when :wait_writable
 							if length > 0
 								self.io_wait(fiber, io, IO::WRITABLE)
 							else
-								return -EAGAIN
+								return -EWOULDBLOCK
 							end
 						when nil
 							break
@@ -218,17 +222,19 @@ module IO::Event
 							buffer.set_string(result, offset)
 							
 							size = result.bytesize
+							total += size
 							offset += size
 							break if size >= length
 							length -= size
 						end
 					end
 					
-					return offset
+					return total
 				end
 				
 				def io_write(fiber, _io, buffer, length, offset = 0)
 					io = IO.for_fd(_io.fileno, autoclose: false)
+					total = 0
 					
 					while true
 						maximum_size = buffer.size - offset
@@ -239,22 +245,23 @@ module IO::Event
 							if length > 0
 								self.io_wait(fiber, io, IO::READABLE)
 							else
-								return -EAGAIN
+								return -EWOULDBLOCK
 							end
 						when :wait_writable
 							if length > 0
 								self.io_wait(fiber, io, IO::WRITABLE)
 							else
-								return -EAGAIN
+								return -EWOULDBLOCK
 							end
 						else
+							total += result
 							offset += result
 							break if result >= length
 							length -= result
 						end
 					end
 					
-					return offset
+					return total
 				end
 				
 				def blocking(&block)

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -10,13 +10,7 @@ require 'io/event/debug/selector'
 require 'socket'
 require 'fiber'
 
-unless Object.const_defined?(:UNIXSocket)
-	class UNIXSocket
-		def self.pair
-			Socket.pair(:INET, :STREAM, 0)
-		end
-	end
-end
+require 'unix_socket'
 
 class FakeFiber
 	def initialize(alive = true)

--- a/test/io/event/selector/buffered_io.rb
+++ b/test/io/event/selector/buffered_io.rb
@@ -9,6 +9,8 @@ require 'io/event'
 require 'io/event/selector'
 require 'socket'
 
+require 'unix_socket'
+
 BufferedIO = Sus::Shared("buffered io") do
 	with 'a pipe' do
 		let(:pipe) {IO.pipe}

--- a/test/io/event/selector/nonblock.rb
+++ b/test/io/event/selector/nonblock.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2022, by Samuel Williams.
+
+require 'io/event'
+require 'io/nonblock'
+
+describe IO::Event::Selector do
+	with '.nonblock' do
+		it "makes non-blocking IO" do
+			executed = false
+			
+			UNIXSocket.pair do |input, output|
+				input.nonblock = false
+				output.nonblock = false
+				
+				IO::Event::Selector.nonblock(input) do
+					executed = true
+					# This does not work on Windows...
+					# expect(input).to be(:nonblock?)
+					# expect(output).not.to be(:nonblock?)
+				end
+			end
+			
+			expect(executed).to be == true
+		end
+	end
+end


### PR DESCRIPTION
Since this is needed for Windows to compile, let's implement it and use it if possible.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.

## [Developer's Certificate of Origin 1.1](https://developercertificate.org/)

<!--
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.
-->

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
