### PR TITLE
Check for `EV_UDATA_SPECIFIC`. Fixes #39.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -50,7 +50,9 @@ if have_header('sys/epoll.h')
 	$srcs << "io/event/selector/epoll.c"
 end
 
-if have_header('sys/event.h')
+# The order matters, because we MUST have EV_UDATA_SPECIFIC.
+# The `have_header` call is just to add the -D to the compiler flags.
+if have_const('EV_UDATA_SPECIFIC', 'sys/event.h') and have_header('sys/event.h')
 	$srcs << "io/event/selector/kqueue.c"
 end
 


### PR DESCRIPTION
Check for `EV_UDATA_SPECIFIC` before building kqueue support which isn't universally supported on systems that support kqueue. See #39 for more details.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
