### PR TITLE
Don't return early - the tests already check if `io_read` is supported.

### DIFF
--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -376,8 +376,8 @@ IO::Event::Selector.constants.each do |name|
 	
 	describe(klass, unique: name) do
 		with '.new' do
-			def count = 8
-			def loop = Fiber.current
+			let(:count) {8}
+			let(:loop) {Fiber.current}
 			
 			it "can create multiple selectors" do
 				selectors = count.times.map do |i|

--- a/test/io/event/selector/buffered_io.rb
+++ b/test/io/event/selector/buffered_io.rb
@@ -3,8 +3,6 @@
 # Released under the MIT License.
 # Copyright, 2021, by Samuel Williams.
 
-return unless IO.const_defined?(:Buffer)
-
 require 'io/event'
 require 'io/event/selector'
 require 'socket'

--- a/test/io/event/selector/file_io.rb
+++ b/test/io/event/selector/file_io.rb
@@ -3,8 +3,6 @@
 # Released under the MIT License.
 # Copyright, 2021-2022, by Samuel Williams.
 
-return unless IO.respond_to?(:Buffer)
-
 require 'io/event'
 require 'io/event/selector'
 require 'tempfile'


### PR DESCRIPTION
Top level `return` is not supported by TruffleRuby.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
