### PR TITLE
Introduce cancellation support for asynchronous `io_read` and `io_write` operations.

### DIFF
--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -236,6 +236,10 @@ module IO::Event
 					end
 					
 					return total
+				rescue IOError => error
+					return -Errno::EBADF::Errno
+				rescue SystemCallError => error
+					return -error.errno
 				end
 				
 				def io_write(fiber, _io, buffer, length, offset = 0)
@@ -268,6 +272,10 @@ module IO::Event
 					end
 					
 					return total
+				rescue IOError => error
+					return -Errno::EBADF::Errno
+				rescue SystemCallError => error
+					return -error.errno
 				end
 				
 				def blocking(&block)

--- a/test/io/event/selector/buffered_io.rb
+++ b/test/io/event/selector/buffered_io.rb
@@ -31,6 +31,17 @@ BufferedIO = Sus::Shared("buffered io") do
 			
 			expect(selector.select(1)).to be >= 1
 		end
+		
+		it "can't write to the read end of a pipe" do
+			writer = Fiber.new do
+				buffer = IO::Buffer.new(64)
+				result = selector.io_write(Fiber.current, input, buffer, 64)
+				expect(result).to be == -Errno::EBADF::Errno
+			end
+			
+			writer.transfer
+			selector.select(1)
+		end
 	end
 end
 

--- a/test/io/event/selector/buffered_io.rb
+++ b/test/io/event/selector/buffered_io.rb
@@ -33,6 +33,8 @@ BufferedIO = Sus::Shared("buffered io") do
 		end
 		
 		it "can't write to the read end of a pipe" do
+			skip "Windows is bonkers" if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
+			
 			writer = Fiber.new do
 				buffer = IO::Buffer.new(64)
 				result = selector.io_write(Fiber.current, input, buffer, 64)


### PR DESCRIPTION
While I'm not sure if there were actually sure if there were any real world use cases hitting this, let's do the best effort to clean up if an exception occurs during an asynchronous read or write operation.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
