### PR TITLE
Add test for zero length write.

### DIFF
--- a/test/io/event/selector/buffered_io.rb
+++ b/test/io/event/selector/buffered_io.rb
@@ -32,6 +32,11 @@ BufferedIO = Sus::Shared("buffered io") do
 			expect(selector.select(1)).to be >= 1
 		end
 		
+		it "can write zero length buffers" do
+			buffer = IO::Buffer.new(1).slice(0, 0)
+			expect(selector.io_write(Fiber.current, output, buffer, 0)).to be == 0
+		end
+		
 		it "can't write to the read end of a pipe" do
 			skip "Windows is bonkers" if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
 			


### PR DESCRIPTION
https://github.com/socketry/async/issues/228

Trying to work around the issue in CRuby which can generate zero length writes.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
