### PR TITLE
Fix `IO_Event_Interrupt_descriptor` undefined symbol.

### DIFF
--- a/ext/io/event/interrupt.h
+++ b/ext/io/event/interrupt.h
@@ -27,7 +27,7 @@ struct IO_Event_Interrupt {
 	int descriptor;
 };
 
-inline int IO_Event_Interrupt_descriptor(struct IO_Event_Interrupt *interrupt) {
+static inline int IO_Event_Interrupt_descriptor(struct IO_Event_Interrupt *interrupt) {
 	return interrupt->descriptor;
 }
 #else
@@ -35,7 +35,7 @@ struct IO_Event_Interrupt {
 	int descriptor[2];
 };
 
-inline int IO_Event_Interrupt_descriptor(struct IO_Event_Interrupt *interrupt) {
+static inline int IO_Event_Interrupt_descriptor(struct IO_Event_Interrupt *interrupt) {
 	return interrupt->descriptor[0];
 }
 #endif


### PR DESCRIPTION
Fixes <https://github.com/socketry/io-event/issues/58>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
