### PR TITLE
Spurious wakeups

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -50,9 +50,9 @@ if have_header('sys/epoll.h')
 	$srcs << "io/event/selector/epoll.c"
 end
 
-# The order matters, because we MUST have EV_UDATA_SPECIFIC.
+# The order matters, because we MUST have EVFILT_USER.
 # The `have_header` call is just to add the -D to the compiler flags.
-if have_const('EV_UDATA_SPECIFIC', 'sys/event.h') and have_header('sys/event.h')
+if have_const('EVFILT_USER', 'sys/event.h') and have_header('sys/event.h')
 	$srcs << "io/event/selector/kqueue.c"
 end
 

--- a/ext/io/event/selector/array.h
+++ b/ext/io/event/selector/array.h
@@ -68,7 +68,7 @@ inline static int IO_Event_Array_resize(struct IO_Event_Array *array, size_t cou
 		new_count *= 2;
 	}
 	
-	void **new_base = (void**)reallocarray(array->base, new_count, sizeof(void*));
+	void **new_base = (void**)realloc(array->base, new_count * sizeof(void*));
 	
 	if (new_base == NULL) {
 		return -1;

--- a/ext/io/event/selector/array.h
+++ b/ext/io/event/selector/array.h
@@ -1,0 +1,113 @@
+// Released under the MIT License.
+// Copyright, 2023, by Samuel Williams.
+
+// Provides a simple implementation of unique pointers to elements of the given size.
+
+#include <stdlib.h>
+#include <errno.h>
+#include <assert.h>
+
+struct IO_Event_Array {
+	// The array of pointers to elements:
+	void **base;
+	
+	// The allocated size of the array:
+	size_t count;
+	
+	// The biggest item we've seen so far:
+	size_t limit;
+	
+	// The size of each element that is allocated:
+	size_t element_size;
+	
+	void (*element_initialize)(void*);
+	void (*element_free)(void*);
+};
+
+inline static void IO_Event_Array_allocate(struct IO_Event_Array *array, size_t count, size_t element_size)
+{
+	if (count) {
+		array->base = (void**)calloc(count, sizeof(void*));
+		array->count = count;
+	} else {
+		array->base = NULL;
+		array->count = 0;
+	}
+	
+	array->limit = 0;
+	array->element_size = element_size;
+}
+
+inline static void IO_Event_Array_free(struct IO_Event_Array *array)
+{
+	for (size_t i = 0; i < array->limit; i += 1) {
+		void *element = array->base[i];
+		if (element) {
+			array->element_free(element);
+			free(element);
+		}
+	}
+	
+	if (array->base)
+		free(array->base);
+	
+	array->base = NULL;
+	array->count = 0;
+	array->limit = 0;
+}
+
+inline static int IO_Event_Array_resize(struct IO_Event_Array *array, size_t count)
+{
+	if (count <= array->count) {
+		return 0;
+	}
+	
+	// Compute the next multiple (ideally a power of 2):
+	size_t new_count = array->count;
+	while (new_count < count) {
+		new_count *= 2;
+	}
+	
+	void **new_base = (void**)reallocarray(array->base, new_count, sizeof(void*));
+	
+	if (new_base == NULL) {
+		return -1;
+	}
+	
+	// Zero out the new memory:
+	memset(new_base + array->count, 0, (new_count - array->count) * sizeof(void*));
+	
+	array->base = (void**)new_base;
+	array->count = new_count;
+	
+	return 1;
+}
+
+inline static void* IO_Event_Array_lookup(struct IO_Event_Array *array, size_t index)
+{
+	size_t count = index + 1;
+	
+	// Resize the array if necessary:
+	if (count > array->count) {
+		if (IO_Event_Array_resize(array, count) == -1) {
+			return NULL;
+		}
+	}
+	
+	// Get the element:
+	void **element = array->base + index;
+	
+	// Allocate the element if it doesn't exist:
+	if (*element == NULL) {
+		*element = malloc(array->element_size);
+		
+		if (array->element_initialize) {
+			array->element_initialize(*element);
+		}
+		
+		// Update the limit:
+		if (count > array->limit) array->limit = count;
+	}
+	
+	return *element;
+}

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -784,7 +784,7 @@ void select_internal_with_gvl(struct select_arguments *arguments) {
 }
 
 static
-void IO_Event_Selector_EPoll_handle(struct IO_Event_Selector_EPoll *selector, const struct epoll_event *event)
+int IO_Event_Selector_EPoll_handle(struct IO_Event_Selector_EPoll *selector, const struct epoll_event *event)
 {
 	int descriptor = event->data.fd;
 	
@@ -824,7 +824,7 @@ void IO_Event_Selector_EPoll_handle(struct IO_Event_Selector_EPoll *selector, co
 		}
 	}
 	
-	IO_Event_Selector_EPoll_Descriptor_update(selector, descriptor, epoll_descriptor);
+	return IO_Event_Selector_EPoll_Descriptor_update(selector, descriptor, epoll_descriptor);
 }
 
 // TODO This function is not re-entrant and we should document and assert as such.

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -748,6 +748,9 @@ void IO_Event_Selector_EPoll_handle(struct IO_Event_Selector_EPoll *selector, co
 	// This is the mask of all events that occured for the given descriptor:
 	enum IO_Event io_event = events_from_epoll_flags(event->events);
 	
+	// This is the mask of all events that we could process:
+	enum IO_Event matched_events = 0, waiting_events = 0;
+	
 	struct IO_Event_Selector_EPoll_Descriptor *epoll_descriptor = IO_Event_Selector_EPoll_Descriptor_lookup(selector, descriptor);
 	struct IO_Event_List *list = &epoll_descriptor->list;
 	struct IO_Event_List *node = list->tail;
@@ -758,10 +761,13 @@ void IO_Event_Selector_EPoll_handle(struct IO_Event_Selector_EPoll *selector, co
 		struct IO_Event_Selector_EPoll_Waiting *waiting = (struct IO_Event_Selector_EPoll_Waiting *)node;
 		
 		enum IO_Event matching_events = waiting->events & io_event;
+		waiting_events |= waiting->events;
 		
 		if (DEBUG) fprintf(stderr, "IO_Event_Selector_EPoll_handle: descriptor=%d, events=%d, matching_events=%d\n", descriptor, io_event, matching_events);
 		
 		if (matching_events) {
+			matched_events |= matching_events;
+			
 			IO_Event_List_append(node, &saved);
 			
 			VALUE argument = RB_INT2NUM(matching_events);
@@ -772,14 +778,6 @@ void IO_Event_Selector_EPoll_handle(struct IO_Event_Selector_EPoll *selector, co
 		} else {
 			node = node->tail;
 		}
-	}
-	
-	// Now that fibers have had a chance to change what events they are waiting on, gather the new union set of events we should be waiting on next for this descriptor.
-	enum IO_Event waiting_events = 0;
-	
-	for (node = list->tail; node != list; node = node->tail) {
-		struct IO_Event_Selector_EPoll_Waiting *waiting = (struct IO_Event_Selector_EPoll_Waiting *)node;
-		waiting_events |= waiting->events;
 	}
 	
 	// ... if we receive events we are not waiting for, we should disable them:

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -388,7 +388,7 @@ VALUE io_wait_transfer(VALUE _arguments) {
 		return Qfalse;
 	}
 	
-	return RB_INT2NUM(events_from_kevent_filter(RB_NUM2INT(result)));
+	return result;
 }
 
 VALUE IO_Event_Selector_KQueue_io_wait(VALUE self, VALUE fiber, VALUE io, VALUE events) {

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -127,6 +127,7 @@ void IO_Event_Selector_KQueue_Descriptor_initialize(void *element)
 	struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = element;
 	IO_Event_List_initialize(&kqueue_descriptor->list);
 	kqueue_descriptor->events = 0;
+	kqueue_descriptor->ready = 0;
 }
 
 void IO_Event_Selector_KQueue_Descriptor_free(void *element)
@@ -451,6 +452,7 @@ VALUE io_read_loop(VALUE _arguments) {
 		if (DEBUG_IO_READ) fprintf(stderr, "read(%d, +%ld, %ld) -> %zd\n", arguments->descriptor, offset, maximum_size, result);
 		
 		if (result > 0) {
+			total += result;
 			offset += result;
 			if ((size_t)result >= length) break;
 			length -= result;

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -103,9 +103,6 @@ static const rb_data_type_t IO_Event_Selector_KQueue_Type = {
 struct IO_Event_Selector_KQueue_Descriptor {
 	struct IO_Event_List list;
 	
-	// The union of all events we are currently waiting on.
-	enum IO_Event events;
-	
 	// The events that are currently ready:
 	enum IO_Event ready;
 };
@@ -126,7 +123,6 @@ void IO_Event_Selector_KQueue_Descriptor_initialize(void *element)
 {
 	struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = element;
 	IO_Event_List_initialize(&kqueue_descriptor->list);
-	kqueue_descriptor->events = 0;
 	kqueue_descriptor->ready = 0;
 }
 
@@ -244,15 +240,12 @@ int IO_Event_Selector_KQueue_arm(struct IO_Event_Selector_KQueue *selector, uint
 	int count = 0;
 	struct kevent kevents[3] = {0};
 	
-	// This operation is additive:
-	enum IO_Event events = kqueue_descriptor->events;
-	
-	if (waiting) events |= waiting->events;
+	enum IO_Event events = waiting->events;
 	
 	if (events & IO_EVENT_READABLE) {
 		kevents[count].ident = ident;
 		kevents[count].filter = EVFILT_READ;
-		kevents[count].flags = EV_ADD | EV_ENABLE;
+		kevents[count].flags = EV_ADD | EV_ENABLE | EV_ONESHOT;
 		kevents[count].udata = (void *)kqueue_descriptor;
 		
 // #ifdef EV_OOBAND
@@ -267,7 +260,7 @@ int IO_Event_Selector_KQueue_arm(struct IO_Event_Selector_KQueue *selector, uint
 	if (events & IO_EVENT_WRITABLE) {
 		kevents[count].ident = ident;
 		kevents[count].filter = EVFILT_WRITE;
-		kevents[count].flags = EV_ADD | EV_ENABLE;
+		kevents[count].flags = EV_ADD | EV_ENABLE | EV_ONESHOT;
 		kevents[count].udata = (void *)kqueue_descriptor;
 		count++;
 	}
@@ -292,11 +285,7 @@ int IO_Event_Selector_KQueue_arm(struct IO_Event_Selector_KQueue *selector, uint
 		rb_sys_fail("IO_Event_Selector_KQueue_arm:kevent");
 	}
 	
-	kqueue_descriptor->events = events;
-	
-	if (waiting) {
-		IO_Event_List_prepend(&kqueue_descriptor->list, &waiting->list);
-	}
+	IO_Event_List_prepend(&kqueue_descriptor->list, &waiting->list);
 	
 	return count;
 }
@@ -718,9 +707,6 @@ void IO_Event_Selector_KQueue_handle(struct IO_Event_Selector_KQueue *selector, 
 		return;
 	}
 	
-	// This is the mask of all events that we could process:
-	enum IO_Event waiting_events = 0;
-	
 	struct IO_Event_List *list = &kqueue_descriptor->list;
 	struct IO_Event_List *node = list->tail;
 	struct IO_Event_List saved = {NULL, NULL};
@@ -730,7 +716,6 @@ void IO_Event_Selector_KQueue_handle(struct IO_Event_Selector_KQueue *selector, 
 		struct IO_Event_Selector_KQueue_Waiting *waiting = (struct IO_Event_Selector_KQueue_Waiting *)node;
 		
 		enum IO_Event matching_events = waiting->events & io_event;
-		waiting_events |= waiting->events;
 		
 		if (DEBUG) fprintf(stderr, "IO_Event_Selector_KQueue_handle: ident=%lu, events=%d, matching_events=%d\n", ident, io_event, matching_events);
 		
@@ -745,12 +730,6 @@ void IO_Event_Selector_KQueue_handle(struct IO_Event_Selector_KQueue *selector, 
 		} else {
 			node = node->tail;
 		}
-	}
-	
-	// ... if we receive events we are not waiting for, we should disable them:
-	if (kqueue_descriptor->events != waiting_events) {
-		kqueue_descriptor->events = waiting_events;
-		IO_Event_Selector_KQueue_arm(selector, ident, kqueue_descriptor, NULL);
 	}
 }
 

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -246,6 +246,7 @@ int IO_Event_Selector_KQueue_arm(struct IO_Event_Selector_KQueue *selector, uint
 		kevents[count].ident = ident;
 		kevents[count].filter = EVFILT_READ;
 		kevents[count].flags = EV_ADD | EV_ENABLE | EV_ONESHOT;
+		kevents[count].udata = (void *)kqueue_descriptor;
 		
 // #ifdef EV_OOBAND
 // 		if (events & IO_EVENT_PRIORITY) {
@@ -260,6 +261,7 @@ int IO_Event_Selector_KQueue_arm(struct IO_Event_Selector_KQueue *selector, uint
 		kevents[count].ident = ident;
 		kevents[count].filter = EVFILT_WRITE;
 		kevents[count].flags = EV_ADD | EV_ENABLE | EV_ONESHOT;
+		kevents[count].udata = (void *)kqueue_descriptor;
 		count++;
 	}
 	
@@ -268,6 +270,7 @@ int IO_Event_Selector_KQueue_arm(struct IO_Event_Selector_KQueue *selector, uint
 		kevents[count].filter = EVFILT_PROC;
 		kevents[count].flags = EV_ADD | EV_ENABLE | EV_ONESHOT;
 		kevents[count].fflags = NOTE_EXIT;
+		kevents[count].udata = (void *)kqueue_descriptor;
 		count++;
 	}
 	
@@ -775,15 +778,15 @@ VALUE IO_Event_Selector_KQueue_select(VALUE self, VALUE duration) {
 	}
 	
 	for (int i = 0; i < arguments.count; i += 1) {
-		struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = IO_Event_Selector_KQueue_Descriptor_lookup(selector, (int)arguments.events[i].ident);
-		if (kqueue_descriptor) {
+		if (arguments.events[i].udata) {
+			struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = arguments.events[i].udata;
 			kqueue_descriptor->ready |= events_from_kevent_filter(arguments.events[i].filter);
 		}
 	}
 	
 	for (int i = 0; i < arguments.count; i += 1) {
-		struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = IO_Event_Selector_KQueue_Descriptor_lookup(selector, (int)arguments.events[i].ident);
-		if (kqueue_descriptor) {
+		if (arguments.events[i].udata) {
+			struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = arguments.events[i].udata;
 			IO_Event_Selector_KQueue_handle(selector, arguments.events[i].ident, kqueue_descriptor);
 		}
 	}

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -246,7 +246,6 @@ int IO_Event_Selector_KQueue_arm(struct IO_Event_Selector_KQueue *selector, uint
 		kevents[count].ident = ident;
 		kevents[count].filter = EVFILT_READ;
 		kevents[count].flags = EV_ADD | EV_ENABLE | EV_ONESHOT;
-		kevents[count].udata = (void *)kqueue_descriptor;
 		
 // #ifdef EV_OOBAND
 // 		if (events & IO_EVENT_PRIORITY) {
@@ -261,7 +260,6 @@ int IO_Event_Selector_KQueue_arm(struct IO_Event_Selector_KQueue *selector, uint
 		kevents[count].ident = ident;
 		kevents[count].filter = EVFILT_WRITE;
 		kevents[count].flags = EV_ADD | EV_ENABLE | EV_ONESHOT;
-		kevents[count].udata = (void *)kqueue_descriptor;
 		count++;
 	}
 	
@@ -270,7 +268,6 @@ int IO_Event_Selector_KQueue_arm(struct IO_Event_Selector_KQueue *selector, uint
 		kevents[count].filter = EVFILT_PROC;
 		kevents[count].flags = EV_ADD | EV_ENABLE | EV_ONESHOT;
 		kevents[count].fflags = NOTE_EXIT;
-		kevents[count].udata = (void *)kqueue_descriptor;
 		count++;
 	}
 	
@@ -778,15 +775,15 @@ VALUE IO_Event_Selector_KQueue_select(VALUE self, VALUE duration) {
 	}
 	
 	for (int i = 0; i < arguments.count; i += 1) {
-		if (arguments.events[i].udata) {
-			struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = arguments.events[i].udata;
+		struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = IO_Event_Selector_KQueue_Descriptor_lookup(selector, (int)arguments.events[i].ident);
+		if (kqueue_descriptor) {
 			kqueue_descriptor->ready |= events_from_kevent_filter(arguments.events[i].filter);
 		}
 	}
 	
 	for (int i = 0; i < arguments.count; i += 1) {
-		if (arguments.events[i].udata) {
-			struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = arguments.events[i].udata;
+		struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = IO_Event_Selector_KQueue_Descriptor_lookup(selector, (int)arguments.events[i].ident);
+		if (kqueue_descriptor) {
 			IO_Event_Selector_KQueue_handle(selector, arguments.events[i].ident, kqueue_descriptor);
 		}
 	}

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -823,10 +823,19 @@ VALUE IO_Event_Selector_KQueue_wakeup(VALUE self) {
 		struct kevent trigger = {0};
 		
 		trigger.filter = EVFILT_USER;
-		trigger.flags = EV_ADD | EV_CLEAR | EV_UDATA_SPECIFIC;
-		trigger.fflags = NOTE_TRIGGER;
+		trigger.flags = EV_ADD | EV_CLEAR;
 		
 		int result = kevent(selector->descriptor, &trigger, 1, NULL, 0, NULL);
+		
+		if (result == -1) {
+			rb_sys_fail("IO_Event_Selector_KQueue_wakeup:kevent");
+		}
+		
+		// FreeBSD apparently only works if the NOTE_TRIGGER is done as a separate call.
+		trigger.flags = 0;
+		trigger.fflags = NOTE_TRIGGER;
+		
+		result = kevent(selector->descriptor, &trigger, 1, NULL, 0, NULL);
 		
 		if (result == -1) {
 			rb_sys_fail("IO_Event_Selector_KQueue_wakeup:kevent");

--- a/ext/io/event/selector/list.h
+++ b/ext/io/event/selector/list.h
@@ -1,6 +1,14 @@
+// Released under the MIT License.
+// Copyright, 2023, by Samuel Williams.
+
+#include <stdio.h>
+#include <assert.h>
 
 struct IO_Event_List {
 	struct IO_Event_List *head, *tail;
+	
+	// We could consider introducing this to deal with non-node types in the list:
+	// void *type;
 };
 
 inline static void IO_Event_List_initialize(struct IO_Event_List *list)
@@ -14,7 +22,19 @@ inline static void IO_Event_List_append(struct IO_Event_List *list, struct IO_Ev
 	assert(node->head == NULL);
 	assert(node->tail == NULL);
 	
+	node->tail = list;
+	list->head->tail = node;
+	node->head = list->head;
+	list->head = node;
+}
+
+inline static void IO_Event_List_prepend(struct IO_Event_List *list, struct IO_Event_List *node)
+{
+	assert(node->head == NULL);
+	assert(node->tail == NULL);
+	
 	node->head = list;
+	list->tail->head = node;
 	node->tail = list->tail;
 	list->tail = node;
 }
@@ -22,7 +42,20 @@ inline static void IO_Event_List_append(struct IO_Event_List *list, struct IO_Ev
 // Pop an item from the list.
 inline static void IO_Event_List_pop(struct IO_Event_List *node)
 {
-	node->head->tail = node->tail;
-	node->tail->head = node->head;
+	assert(node->head != NULL);
+	assert(node->tail != NULL);
+	
+	struct IO_Event_List *head = node->head;
+	struct IO_Event_List *tail = node->tail;
+	
+	head->tail = tail;
+	tail->head = head;
 	node->head = node->tail = NULL;
+}
+
+inline static void IO_Event_List_free(struct IO_Event_List *node)
+{
+	if (node->head != node->tail) {
+		IO_Event_List_pop(node);
+	}
 }

--- a/ext/io/event/selector/list.h
+++ b/ext/io/event/selector/list.h
@@ -1,0 +1,28 @@
+
+struct IO_Event_List {
+	struct IO_Event_List *head, *tail;
+};
+
+inline static void IO_Event_List_initialize(struct IO_Event_List *list)
+{
+	list->head = list->tail = list;
+}
+
+// Append an item to the end of the list.
+inline static void IO_Event_List_append(struct IO_Event_List *list, struct IO_Event_List *node)
+{
+	assert(node->head == NULL);
+	assert(node->tail == NULL);
+	
+	node->head = list;
+	node->tail = list->tail;
+	list->tail = node;
+}
+
+// Pop an item from the list.
+inline static void IO_Event_List_pop(struct IO_Event_List *node)
+{
+	node->head->tail = node->tail;
+	node->tail->head = node->head;
+	node->head = node->tail = NULL;
+}

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -40,7 +40,10 @@ enum IO_Event {
 	IO_EVENT_PRIORITY = 2,
 	IO_EVENT_WRITABLE = 4,
 	IO_EVENT_ERROR = 8,
-	IO_EVENT_HANGUP = 16
+	IO_EVENT_HANGUP = 16,
+	
+	// Used by kqueue to differentiate between process exit and file descriptor events:
+	IO_EVENT_EXIT = 32,
 };
 
 void Init_IO_Event_Selector(VALUE IO_Event_Selector);

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -132,28 +132,3 @@ void IO_Event_Selector_current_time(struct timespec *time);
 
 #define PRINTF_TIMESPEC "%lld.%.9ld"
 #define PRINTF_TIMESPEC_ARGS(ts) (long long)((ts).tv_sec), (ts).tv_nsec
-
-inline static void* IO_Event_Array_resize(void *base, size_t size, size_t new_size, size_t element_size)
-{
-	assert(new_size >= size);
-	
-	if (new_size == size) {
-		return base;
-	}
-	
-	void *new_base = realloc(base, new_size * element_size);
-	
-	if (new_base == NULL) {
-		return NULL;
-	}
-	
-	// Zero the new memory.
-	memset((char*)new_base + size * element_size, 0, (new_size - size) * element_size);
-	
-	return new_base;
-}
-
-inline static void IO_Event_Array_free(void *base)
-{
-	free(base);
-}

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -132,3 +132,28 @@ void IO_Event_Selector_current_time(struct timespec *time);
 
 #define PRINTF_TIMESPEC "%lld.%.9ld"
 #define PRINTF_TIMESPEC_ARGS(ts) (long long)((ts).tv_sec), (ts).tv_nsec
+
+inline static void* IO_Event_Array_resize(void *base, size_t size, size_t new_size, size_t element_size)
+{
+	assert(new_size >= size);
+	
+	if (new_size == size) {
+		return base;
+	}
+	
+	void *new_base = realloc(base, new_size * element_size);
+	
+	if (new_base == NULL) {
+		return NULL;
+	}
+	
+	// Zero the new memory.
+	memset((char*)new_base + size * element_size, 0, (new_size - size) * element_size);
+	
+	return new_base;
+}
+
+inline static void IO_Event_Array_free(void *base)
+{
+	free(base);
+}

--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -165,8 +165,8 @@ module IO::Event
 					total = 0
 					
 					Selector.nonblock(io) do
-						while true
-							maximum_size = buffer.size - offset
+						maximum_size = buffer.size - offset
+						while maximum_size > 0
 							result = Fiber.blocking{buffer.read(io, maximum_size, offset)}
 							
 							if again?(result)
@@ -182,6 +182,8 @@ module IO::Event
 								offset += result
 								break if total >= length
 							end
+							
+							maximum_size = buffer.size - offset
 						end
 					end
 					
@@ -192,8 +194,8 @@ module IO::Event
 					total = 0
 					
 					Selector.nonblock(io) do
-						while true
-							maximum_size = buffer.size - offset
+						maximum_size = buffer.size - offset
+						while maximum_size > 0
 							result = Fiber.blocking{buffer.write(io, maximum_size, offset)}
 							
 							if again?(result)
@@ -209,6 +211,8 @@ module IO::Event
 								offset += result
 								break if total >= length
 							end
+							
+							maximum_size = buffer.size - offset
 						end
 					end
 					
@@ -219,9 +223,8 @@ module IO::Event
 					io = IO.for_fd(_io.fileno, autoclose: false)
 					total = 0
 					
-					while true
-						maximum_size = buffer.size - offset
-						
+					maximum_size = buffer.size - offset
+					while maximum_size > 0
 						case result = blocking{io.read_nonblock(maximum_size, exception: false)}
 						when :wait_readable
 							if length > 0
@@ -246,6 +249,8 @@ module IO::Event
 							break if size >= length
 							length -= size
 						end
+						
+						maximum_size = buffer.size - offset
 					end
 					
 					return total
@@ -259,9 +264,8 @@ module IO::Event
 					io = IO.for_fd(_io.fileno, autoclose: false)
 					total = 0
 					
-					while true
-						maximum_size = buffer.size - offset
-						
+					maximum_size = buffer.size - offset
+					while maximum_size > 0
 						chunk = buffer.get_string(offset, maximum_size)
 						case result = blocking{io.write_nonblock(chunk, exception: false)}
 						when :wait_readable
@@ -282,6 +286,8 @@ module IO::Event
 							break if result >= length
 							length -= result
 						end
+						
+						maximum_size = buffer.size - offset
 					end
 					
 					return total

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -398,9 +398,13 @@ Selector = Sus::Shared("a selector") do
 			
 			remote.write(message)
 			
-			10.times do
-				expect(selector.select(0)).to be == 0
+			result = nil
+			3.times do
+				result = selector.select(0)
+				break if result == 0
 			end
+			
+			expect(result).to be == 0
 		end
 	end
 	

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -283,6 +283,49 @@ Selector = Sus::Shared("a selector") do
 				:select, :readable, :readable
 			]
 		end
+		
+		it "can handle exception raised during wait from another fiber that was waiting on the same io" do
+			[false, true].each do |swapped| # Try both orderings.
+				writable1 = writable2 = false
+				error1 = false
+				raised1 = false
+				
+				boom = Class.new(RuntimeError)
+				
+				fiber1 = fiber2 = nil
+				
+				fiber1 = Fiber.new do
+					begin
+						selector.io_wait(Fiber.current, local, IO::WRITABLE)
+					rescue boom
+						error1 = true
+						# Transfer back to the signaling fiber to simulate doing something similar to raising an exception in an asynchronous task or thread.
+						fiber2.transfer
+					end
+					writable1 = true
+				end
+				
+				fiber2 = Fiber.new do
+					selector.io_wait(Fiber.current, local, IO::WRITABLE)
+					# Don't do anything if the other fiber was resumed before we were by the selector.
+					unless writable1
+						raised1 = true
+						fiber1.raise(boom) # Will return here.
+					end
+					writable2 = true
+				end
+				
+				fiber1.transfer unless swapped
+				fiber2.transfer
+				fiber1.transfer if swapped
+				selector.select(0)
+				
+				# If fiber2 did manage to be resumed by the selector before fiber1, it should have raised an exception in fiber1, and fiber1 should not have been resumed by the selector since its #io_wait call should have been cancelled.
+				expect(error1).to be == raised1
+				expect(writable1).to be == !raised1
+				expect(writable2).to be == true
+			end
+		end
 	end
 	
 	with '#io_read' do

--- a/test/io/event/selector/buffered_io.rb
+++ b/test/io/event/selector/buffered_io.rb
@@ -38,6 +38,23 @@ BufferedIO = Sus::Shared("buffered io") do
 			expect(selector.io_write(Fiber.current, output, buffer, 0)).to be == 0
 		end
 		
+		it "can read and write at the specified offset" do
+			writer = Fiber.new do
+				buffer = IO::Buffer.new(128)
+				expect(selector.io_write(Fiber.current, output, buffer, 128, 64)).to be == 64
+			end
+			
+			reader = Fiber.new do
+				buffer = IO::Buffer.new(128)
+				expect(selector.io_read(Fiber.current, input, buffer, 1, 64)).to be == 64
+			end
+			
+			reader.transfer
+			writer.transfer
+			
+			expect(selector.select(1)).to be >= 1
+		end
+		
 		it "can't write to the read end of a pipe" do
 			skip "Windows is bonkers" if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
 			bsd = RUBY_PLATFORM =~ /bsd/


### PR DESCRIPTION
As discussed in <https://github.com/socketry/io-event/issues/65>, it's possible for the list of events in `IO_Event_Selector_EPoll_select` to contain cancelled operations. If during cancellation, another operation is scheduled, a spurious wakeup can be generated. Adding one layer of indirection, in the form of cancelled tokens, avoids this situation, since each operation has a unique token which can independently be cancelled.

The overhead of this is extra memory allocations, but these can be pooled. We could compare the cost of `malloc`. There may be little point pooling these tokens.

Fixes #65.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
