### PR TITLE
Always re-register epoll descriptor.

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -167,15 +167,15 @@ int events_from_epoll_flags(uint32_t flags)
 inline static
 int IO_Event_Selector_EPoll_Descriptor_update(struct IO_Event_Selector_EPoll *selector, int descriptor, struct IO_Event_Selector_EPoll_Descriptor *epoll_descriptor)
 {
-	if (epoll_descriptor->registered_events == epoll_descriptor->waiting_events) {
-		// All the events we are interested in are already registered.
-		return 0;
-	}
+	// if (epoll_descriptor->registered_events == epoll_descriptor->waiting_events) {
+	// 	// All the events we are interested in are already registered.
+	// 	return 0;
+	// }
 	
 	if (epoll_descriptor->waiting_events == 0) {
 		// We are no longer interested in any events.
 		int result = epoll_ctl(selector->descriptor, EPOLL_CTL_DEL, descriptor, NULL);
-		if (result == -1) return -1;
+		// if (result == -1) return -1;
 		
 		epoll_descriptor->registered_events = 0;
 		
@@ -197,7 +197,15 @@ int IO_Event_Selector_EPoll_Descriptor_update(struct IO_Event_Selector_EPoll *se
 	}
 	
 	int result = epoll_ctl(selector->descriptor, operation, descriptor, &event);
-	if (result == -1) return -1;
+	if (result == -1) {
+		if (errno == ENOENT) {
+			result = epoll_ctl(selector->descriptor, EPOLL_CTL_ADD, descriptor, &event);
+		}
+		
+		if (result == -1) {
+			return -1;
+		}
+	}
 	
 	epoll_descriptor->registered_events = epoll_descriptor->waiting_events;
 	

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -150,10 +150,10 @@ enum IO_Event events_from_kevent_filter(int filter)
 inline static
 int IO_Event_Selector_KQueue_Descriptor_update(struct IO_Event_Selector_KQueue *selector, uintptr_t identifier, struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor)
 {
-	if (kqueue_descriptor->registered_events == kqueue_descriptor->waiting_events) {
-		// All the events we are interested in are already registered.
-		return 0;
-	}
+	// if (kqueue_descriptor->registered_events == kqueue_descriptor->waiting_events) {
+	// 	// All the events we are interested in are already registered.
+	// 	return 0;
+	// }
 	
 	int count = 0;
 	struct kevent kevents[3] = {0};


### PR DESCRIPTION
<https://github.com/socketry/io-event/pull/69> introduced a failing test case.

File descriptors may be reused. Caching based on descriptor can therefore cause missing registrations.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
