### PR TITLE
Introduce correct support for compacting GC.

### DIFF
--- a/ext/io/event/selector/array.h
+++ b/ext/io/event/selector/array.h
@@ -117,3 +117,13 @@ inline static void* IO_Event_Array_push(struct IO_Event_Array *array)
 {
 	return IO_Event_Array_lookup(array, array->limit);
 }
+
+inline static void IO_Event_Array_each(struct IO_Event_Array *array, void (*callback)(void*))
+{
+	for (size_t i = 0; i < array->limit; i += 1) {
+		void *element = array->base[i];
+		if (element) {
+			callback(element);
+		}
+	}
+}

--- a/ext/io/event/selector/array.h
+++ b/ext/io/event/selector/array.h
@@ -38,6 +38,12 @@ inline static void IO_Event_Array_allocate(struct IO_Event_Array *array, size_t 
 	array->element_size = element_size;
 }
 
+inline static size_t IO_Event_Array_memory_size(const struct IO_Event_Array *array)
+{
+	// Upper bound.
+	return array->count * (sizeof(void*) + array->element_size);
+}
+
 inline static void IO_Event_Array_free(struct IO_Event_Array *array)
 {
 	for (size_t i = 0; i < array->limit; i += 1) {

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -84,7 +84,7 @@ void IO_Event_Selector_EPoll_Waiting_mark(struct IO_Event_List *_waiting)
 	struct IO_Event_Selector_EPoll_Waiting *waiting = (void*)_waiting;
 	
 	if (waiting->fiber) {
-		RUBY_MARK_MOVABLE_UNLESS_NULL(waiting->fiber);
+		rb_gc_mark_movable(waiting->fiber);
 	}
 }
 

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -153,9 +153,13 @@ void IO_Event_Selector_EPoll_Type_free(void *_selector)
 }
 
 static
-size_t IO_Event_Selector_EPoll_Type_size(const void *selector)
+size_t IO_Event_Selector_EPoll_Type_size(const void *_selector)
 {
-	return sizeof(struct IO_Event_Selector_EPoll);
+	const struct IO_Event_Selector_EPoll *selector = _selector;
+	
+	return sizeof(struct IO_Event_Selector_EPoll)
+		+ IO_Event_Array_memory_size(&selector->descriptors)
+	;
 }
 
 static const rb_data_type_t IO_Event_Selector_EPoll_Type = {

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -83,7 +83,9 @@ void IO_Event_Selector_EPoll_Waiting_mark(struct IO_Event_List *_waiting)
 {
 	struct IO_Event_Selector_EPoll_Waiting *waiting = (void*)_waiting;
 	
-	rb_gc_mark_movable(waiting->fiber);
+	if (waiting->fiber) {
+		RUBY_MARK_MOVABLE_UNLESS_NULL(waiting->fiber);
+	}
 }
 
 static
@@ -109,7 +111,9 @@ void IO_Event_Selector_EPoll_Waiting_compact(struct IO_Event_List *_waiting)
 {
 	struct IO_Event_Selector_EPoll_Waiting *waiting = (void*)_waiting;
 	
-	waiting->fiber = rb_gc_location(waiting->fiber);
+	if (waiting->fiber) {
+		waiting->fiber = rb_gc_location(waiting->fiber);
+	}
 }
 
 static

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -63,50 +63,6 @@ struct IO_Event_Selector_EPoll
 	struct IO_Event_Array descriptors;
 };
 
-void IO_Event_Selector_EPoll_Type_mark(void *_selector)
-{
-	struct IO_Event_Selector_EPoll *selector = _selector;
-	IO_Event_Selector_mark(&selector->backend);
-}
-
-static
-void close_internal(struct IO_Event_Selector_EPoll *selector)
-{
-	if (selector->descriptor >= 0) {
-		close(selector->descriptor);
-		selector->descriptor = -1;
-		
-		IO_Event_Interrupt_close(&selector->interrupt);
-	}
-}
-
-void IO_Event_Selector_EPoll_Type_free(void *_selector)
-{
-	struct IO_Event_Selector_EPoll *selector = _selector;
-	
-	close_internal(selector);
-	
-	IO_Event_Array_free(&selector->descriptors);
-	
-	free(selector);
-}
-
-size_t IO_Event_Selector_EPoll_Type_size(const void *selector)
-{
-	return sizeof(struct IO_Event_Selector_EPoll);
-}
-
-static const rb_data_type_t IO_Event_Selector_EPoll_Type = {
-	.wrap_struct_name = "IO_Event::Backend::EPoll",
-	.function = {
-		.dmark = IO_Event_Selector_EPoll_Type_mark,
-		.dfree = IO_Event_Selector_EPoll_Type_free,
-		.dsize = IO_Event_Selector_EPoll_Type_size,
-	},
-	.data = NULL,
-	.flags = RUBY_TYPED_FREE_IMMEDIATELY,
-};
-
 // This represents zero or more fibers waiting for a specific descriptor.
 struct IO_Event_Selector_EPoll_Descriptor
 {
@@ -120,6 +76,98 @@ struct IO_Event_Selector_EPoll_Descriptor
 	
 	// The union of events we are registered for:
 	enum IO_Event registered_events;
+};
+
+static
+void IO_Event_Selector_EPoll_Waiting_mark(struct IO_Event_List *_waiting)
+{
+	struct IO_Event_Selector_EPoll_Waiting *waiting = (void*)_waiting;
+	
+	rb_gc_mark_movable(waiting->fiber);
+}
+
+static
+void IO_Event_Selector_EPoll_Descriptor_mark(void *_descriptor)
+{
+	struct IO_Event_Selector_EPoll_Descriptor *descriptor = _descriptor;
+	
+	IO_Event_List_immutable_each(&descriptor->list, IO_Event_Selector_EPoll_Waiting_mark);
+	rb_gc_mark_movable(descriptor->io);
+}
+
+static
+void IO_Event_Selector_EPoll_Type_mark(void *_selector)
+{
+	struct IO_Event_Selector_EPoll *selector = _selector;
+	
+	IO_Event_Selector_mark(&selector->backend);
+	IO_Event_Array_each(&selector->descriptors, IO_Event_Selector_EPoll_Descriptor_mark);
+}
+
+static
+void IO_Event_Selector_EPoll_Waiting_compact(struct IO_Event_List *_waiting)
+{
+	struct IO_Event_Selector_EPoll_Waiting *waiting = (void*)_waiting;
+	
+	waiting->fiber = rb_gc_location(waiting->fiber);
+}
+
+static
+void IO_Event_Selector_EPoll_Descriptor_compact(void *_descriptor)
+{
+	struct IO_Event_Selector_EPoll_Descriptor *descriptor = _descriptor;
+	
+	IO_Event_List_immutable_each(&descriptor->list, IO_Event_Selector_EPoll_Waiting_compact);
+	descriptor->io = rb_gc_location(descriptor->io);
+}
+
+static
+void IO_Event_Selector_EPoll_Type_compact(void *_selector)
+{
+	struct IO_Event_Selector_EPoll *selector = _selector;
+	
+	IO_Event_Selector_compact(&selector->backend);
+	IO_Event_Array_each(&selector->descriptors, IO_Event_Selector_EPoll_Descriptor_compact);
+}
+
+static
+void close_internal(struct IO_Event_Selector_EPoll *selector)
+{
+	if (selector->descriptor >= 0) {
+		close(selector->descriptor);
+		selector->descriptor = -1;
+		
+		IO_Event_Interrupt_close(&selector->interrupt);
+	}
+}
+static
+void IO_Event_Selector_EPoll_Type_free(void *_selector)
+{
+	struct IO_Event_Selector_EPoll *selector = _selector;
+	
+	close_internal(selector);
+	
+	IO_Event_Array_free(&selector->descriptors);
+	
+	free(selector);
+}
+
+static
+size_t IO_Event_Selector_EPoll_Type_size(const void *selector)
+{
+	return sizeof(struct IO_Event_Selector_EPoll);
+}
+
+static const rb_data_type_t IO_Event_Selector_EPoll_Type = {
+	.wrap_struct_name = "IO_Event::Backend::EPoll",
+	.function = {
+		.dmark = IO_Event_Selector_EPoll_Type_mark,
+		.dcompact = IO_Event_Selector_EPoll_Type_compact,
+		.dfree = IO_Event_Selector_EPoll_Type_free,
+		.dsize = IO_Event_Selector_EPoll_Type_size,
+	},
+	.data = NULL,
+	.flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 inline static

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -95,7 +95,7 @@ void IO_Event_Selector_KQueue_Waiting_mark(struct IO_Event_List *_waiting)
 	struct IO_Event_Selector_KQueue_Waiting *waiting = (void*)_waiting;
 	
 	if (waiting->fiber) {
-		RUBY_MARK_MOVABLE_UNLESS_NULL(waiting->fiber);
+		rb_gc_mark_movable(waiting->fiber);
 	}
 }
 

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -94,7 +94,9 @@ void IO_Event_Selector_KQueue_Waiting_mark(struct IO_Event_List *_waiting)
 {
 	struct IO_Event_Selector_KQueue_Waiting *waiting = (void*)_waiting;
 	
-	rb_gc_mark_movable(waiting->fiber);
+	if (waiting->fiber) {
+		RUBY_MARK_MOVABLE_UNLESS_NULL(waiting->fiber);
+	}
 }
 
 static
@@ -103,7 +105,6 @@ void IO_Event_Selector_KQueue_Descriptor_mark(void *_descriptor)
 	struct IO_Event_Selector_KQueue_Descriptor *descriptor = _descriptor;
 	
 	IO_Event_List_immutable_each(&descriptor->list, IO_Event_Selector_KQueue_Waiting_mark);
-	rb_gc_mark_movable(descriptor->io);
 }
 
 static
@@ -119,7 +120,9 @@ void IO_Event_Selector_KQueue_Waiting_compact(struct IO_Event_List *_waiting)
 {
 	struct IO_Event_Selector_KQueue_Waiting *waiting = (void*)_waiting;
 	
-	rb_gc_location(waiting->fiber);
+	if (waiting->fiber) {
+		rb_gc_location(waiting->fiber);
+	}
 }
 
 static

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -74,48 +74,6 @@ struct IO_Event_Selector_KQueue
 	struct IO_Event_Array descriptors;
 };
 
-void IO_Event_Selector_KQueue_Type_mark(void *_selector)
-{
-	struct IO_Event_Selector_KQueue *selector = _selector;
-	IO_Event_Selector_mark(&selector->backend);
-}
-
-static
-void close_internal(struct IO_Event_Selector_KQueue *selector)
-{
-	if (selector->descriptor >= 0) {
-		close(selector->descriptor);
-		selector->descriptor = -1;
-	}
-}
-
-void IO_Event_Selector_KQueue_Type_free(void *_selector)
-{
-	struct IO_Event_Selector_KQueue *selector = _selector;
-	
-	close_internal(selector);
-	
-	IO_Event_Array_free(&selector->descriptors);
-	
-	free(selector);
-}
-
-size_t IO_Event_Selector_KQueue_Type_size(const void *selector)
-{
-	return sizeof(struct IO_Event_Selector_KQueue);
-}
-
-static const rb_data_type_t IO_Event_Selector_KQueue_Type = {
-	.wrap_struct_name = "IO_Event::Backend::KQueue",
-	.function = {
-		.dmark = IO_Event_Selector_KQueue_Type_mark,
-		.dfree = IO_Event_Selector_KQueue_Type_free,
-		.dsize = IO_Event_Selector_KQueue_Type_size,
-	},
-	.data = NULL,
-	.flags = RUBY_TYPED_FREE_IMMEDIATELY,
-};
-
 // This represents zero or more fibers waiting for a specific descriptor.
 struct IO_Event_Selector_KQueue_Descriptor
 {
@@ -129,6 +87,94 @@ struct IO_Event_Selector_KQueue_Descriptor
 	
 	// The events that are currently ready:
 	enum IO_Event ready_events;
+};
+
+static
+void IO_Event_Selector_KQueue_Waiting_mark(struct IO_Event_List *_waiting)
+{
+	struct IO_Event_Selector_KQueue_Waiting *waiting = (void*)_waiting;
+	
+	rb_gc_mark_movable(waiting->fiber);
+}
+
+static
+void IO_Event_Selector_KQueue_Descriptor_mark(void *_descriptor)
+{
+	struct IO_Event_Selector_KQueue_Descriptor *descriptor = _descriptor;
+	
+	IO_Event_List_immutable_each(&descriptor->list, IO_Event_Selector_KQueue_Waiting_mark);
+	rb_gc_mark_movable(descriptor->io);
+}
+
+static
+void IO_Event_Selector_KQueue_Type_mark(void *_selector)
+{
+	struct IO_Event_Selector_KQueue *selector = _selector;
+	IO_Event_Selector_mark(&selector->backend);
+	IO_Event_Array_each(&selector->descriptors, IO_Event_Selector_KQueue_Descriptor_mark);
+}
+
+static
+void IO_Event_Selector_KQueue_Waiting_compact(struct IO_Event_List *_waiting)
+{
+	struct IO_Event_Selector_KQueue_Waiting *waiting = (void*)_waiting;
+	
+	rb_gc_location(waiting->fiber);
+}
+
+static
+void IO_Event_Selector_KQueue_Descriptor_compact(void *_descriptor)
+{
+	struct IO_Event_Selector_KQueue_Descriptor *descriptor = _descriptor;
+	
+	IO_Event_List_immutable_each(&descriptor->list, IO_Event_Selector_KQueue_Waiting_compact);
+}
+
+static
+void IO_Event_Selector_KQueue_Type_compact(void *_selector)
+{
+	struct IO_Event_Selector_KQueue *selector = _selector;
+	IO_Event_Selector_compact(&selector->backend);
+	IO_Event_Array_each(&selector->descriptors, IO_Event_Selector_KQueue_Descriptor_compact);
+}
+
+static
+void close_internal(struct IO_Event_Selector_KQueue *selector)
+{
+	if (selector->descriptor >= 0) {
+		close(selector->descriptor);
+		selector->descriptor = -1;
+	}
+}
+
+static
+void IO_Event_Selector_KQueue_Type_free(void *_selector)
+{
+	struct IO_Event_Selector_KQueue *selector = _selector;
+	
+	close_internal(selector);
+	
+	IO_Event_Array_free(&selector->descriptors);
+	
+	free(selector);
+}
+
+static
+size_t IO_Event_Selector_KQueue_Type_size(const void *selector)
+{
+	return sizeof(struct IO_Event_Selector_KQueue);
+}
+
+static const rb_data_type_t IO_Event_Selector_KQueue_Type = {
+	.wrap_struct_name = "IO_Event::Backend::KQueue",
+	.function = {
+		.dmark = IO_Event_Selector_KQueue_Type_mark,
+		.dcompact = IO_Event_Selector_KQueue_Type_compact,
+		.dfree = IO_Event_Selector_KQueue_Type_free,
+		.dsize = IO_Event_Selector_KQueue_Type_size,
+	},
+	.data = NULL,
+	.flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 inline static

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -160,9 +160,13 @@ void IO_Event_Selector_KQueue_Type_free(void *_selector)
 }
 
 static
-size_t IO_Event_Selector_KQueue_Type_size(const void *selector)
+size_t IO_Event_Selector_KQueue_Type_size(const void *_selector)
 {
-	return sizeof(struct IO_Event_Selector_KQueue);
+	const struct IO_Event_Selector_KQueue *selector = _selector;
+	
+	return sizeof(struct IO_Event_Selector_KQueue)
+		+ IO_Event_Array_memory_size(&selector->descriptors)
+	;
 }
 
 static const rb_data_type_t IO_Event_Selector_KQueue_Type = {

--- a/ext/io/event/selector/list.h
+++ b/ext/io/event/selector/list.h
@@ -69,3 +69,14 @@ inline static int IO_Event_List_empty(struct IO_Event_List *list)
 {
 	return list->head == list->tail;
 }
+
+inline static void IO_Event_List_immutable_each(struct IO_Event_List *list, void (*callback)(struct IO_Event_List *node))
+{
+	struct IO_Event_List *node = list->tail;
+	
+	while (node != list) {
+		callback(node);
+		
+		node = node->tail;
+	}
+}

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -131,9 +131,13 @@ void IO_Event_Selector_URing_Type_free(void *_selector)
 }
 
 static
-size_t IO_Event_Selector_URing_Type_size(const void *selector)
+size_t IO_Event_Selector_URing_Type_size(const void *_selector)
 {
-	return sizeof(struct IO_Event_Selector_URing);
+	const struct IO_Event_Selector_URing *selector = _selector;
+	
+	return sizeof(struct IO_Event_Selector_URing)
+		+ IO_Event_Array_memory_size(&selector->completions)
+	;
 }
 
 static const rb_data_type_t IO_Event_Selector_URing_Type = {


### PR DESCRIPTION
Fix our garbage collection and add support for compacting GC.

This also ensures that all fibers are retained if they are waiting in the event loop, a departure from existing behaviour (probably for the better).

cc @nevans

See also: https://bugs.ruby-lang.org/issues/18818

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
