### PR TITLE
Correctly pass through flags `rb_process_status_wait`.

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -446,6 +446,7 @@ struct process_wait_arguments {
 	struct IO_Event_Selector_EPoll *selector;
 	struct IO_Event_Selector_EPoll_Waiting *waiting;
 	int pid;
+	int flags;
 	int descriptor;
 };
 
@@ -456,7 +457,7 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	IO_Event_Selector_fiber_transfer(arguments->selector->backend.loop, 0, NULL);
 	
 	if (arguments->waiting->ready) {
-		return IO_Event_Selector_process_status_wait(arguments->pid);
+		return IO_Event_Selector_process_status_wait(arguments->pid, arguments->flags);
 	} else {
 		return Qfalse;
 	}
@@ -480,7 +481,7 @@ VALUE IO_Event_Selector_EPoll_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 	TypedData_Get_Struct(self, struct IO_Event_Selector_EPoll, &IO_Event_Selector_EPoll_Type, selector);
 	
 	pid_t pid = NUM2PIDT(_pid);
-	// int flags = NUM2INT(_flags);
+	int flags = NUM2INT(_flags);
 	
 	int descriptor = pidfd_open(pid, 0);
 	
@@ -506,6 +507,7 @@ VALUE IO_Event_Selector_EPoll_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 	struct process_wait_arguments process_wait_arguments = {
 		.selector = selector,
 		.pid = pid,
+		.flags = flags,
 		.descriptor = descriptor,
 		.waiting = &waiting,
 	};

--- a/ext/io/event/selector/selector.c
+++ b/ext/io/event/selector/selector.c
@@ -25,10 +25,6 @@ static const int DEBUG = 0;
 
 static ID id_transfer, id_alive_p;
 
-#ifndef HAVE_RB_PROCESS_STATUS_WAIT
-static VALUE process_wnohang;
-#endif
-
 VALUE IO_Event_Selector_fiber_transfer(VALUE fiber, int argc, VALUE *argv) {
 	// TODO Consider introducing something like `rb_fiber_scheduler_transfer(...)`.
 #ifdef HAVE__RB_FIBER_TRANSFER
@@ -76,9 +72,9 @@ int IO_Event_Selector_io_descriptor(VALUE io) {
 static ID id_wait;
 static VALUE rb_Process_Status = Qnil;
 
-VALUE IO_Event_Selector_process_status_wait(rb_pid_t pid)
+VALUE IO_Event_Selector_process_status_wait(rb_pid_t pid, int flags)
 {
-	return rb_funcall(rb_Process_Status, id_wait, 2, PIDT2NUM(pid), process_wnohang);
+	return rb_funcall(rb_Process_Status, id_wait, 2, PIDT2NUM(pid), INT2NUM(flags | WNOHANG));
 }
 #endif
 
@@ -157,7 +153,6 @@ void Init_IO_Event_Selector(VALUE IO_Event_Selector) {
 	
 #ifndef HAVE_RB_PROCESS_STATUS_WAIT
 	id_wait = rb_intern("wait");
-	process_wnohang = rb_const_get(rb_mProcess, rb_intern("WNOHANG"));
 	rb_Process_Status = rb_const_get_at(rb_mProcess, rb_intern("Status"));
 	rb_gc_register_mark_object(rb_Process_Status);
 #endif

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -66,10 +66,11 @@ VALUE IO_Event_Selector_fiber_raise(VALUE fiber, int argc, VALUE *argv);
 int IO_Event_Selector_io_descriptor(VALUE io);
 #endif
 
+// Reap a process without hanging.
 #ifdef HAVE_RB_PROCESS_STATUS_WAIT
-#define IO_Event_Selector_process_status_wait(pid) rb_process_status_wait(pid)
+#define IO_Event_Selector_process_status_wait(pid, flags) rb_process_status_wait(pid, flags | WNOHANG)
 #else
-VALUE IO_Event_Selector_process_status_wait(rb_pid_t pid);
+VALUE IO_Event_Selector_process_status_wait(rb_pid_t pid, int flags);
 #endif
 
 int IO_Event_Selector_nonblock_set(int file_descriptor);

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -428,6 +428,7 @@ struct process_wait_arguments {
 	struct IO_Event_Selector_URing_Waiting *waiting;
 	
 	pid_t pid;
+	int flags;
 	int descriptor;
 };
 
@@ -438,7 +439,7 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	IO_Event_Selector_fiber_transfer(arguments->selector->backend.loop, 0, NULL);
 	
 	if (arguments->waiting->result) {
-		return IO_Event_Selector_process_status_wait(arguments->pid);
+		return IO_Event_Selector_process_status_wait(arguments->pid, arguments->flags);
 	} else {
 		return Qfalse;
 	}
@@ -460,6 +461,7 @@ VALUE IO_Event_Selector_URing_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, selector);
 	
 	pid_t pid = NUM2PIDT(_pid);
+	int flags = NUM2INT(_flags);
 	
 	int descriptor = pidfd_open(pid, 0);
 	if (descriptor < 0) {
@@ -477,6 +479,7 @@ VALUE IO_Event_Selector_URing_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 		.selector = selector,
 		.waiting = &waiting,
 		.pid = pid,
+		.flags = flags,
 		.descriptor = descriptor,
 	};
 	


### PR DESCRIPTION
`rb_process_status_wait` is not exposed yet in CRuby, but when/if it is, it will take a flags argument.

`WNOHANG` should always be set, as it's used to (efficiently) by-pass the fiber scheduler.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
