### PR TITLE
Always #include <ruby.h> before any system header

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,9 @@ jobs:
             ruby: truffleruby
             experimental: true
           - os: ubuntu
+            ruby: truffleruby-head
+            experimental: true
+          - os: ubuntu
             ruby: jruby
             experimental: true
           - os: ubuntu

--- a/ext/io/event/event.h
+++ b/ext/io/event/event.h
@@ -22,8 +22,6 @@
 
 #include <ruby.h>
 
-#include "extconf.h"
-
 void Init_IO_Event(void);
 
 #ifdef HAVE_LIBURING_H

--- a/ext/io/event/interrupt.h
+++ b/ext/io/event/interrupt.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "extconf.h"
+#include <ruby.h>
 
 #ifdef HAVE_SYS_EVENTFD_H
 struct IO_Event_Interrupt {

--- a/ext/io/event/selector/array.h
+++ b/ext/io/event/selector/array.h
@@ -3,6 +3,7 @@
 
 // Provides a simple implementation of unique pointers to elements of the given size.
 
+#include <ruby.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <assert.h>

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "kqueue.h"
+#include "epoll.h"
 #include "selector.h"
 #include "list.h"
 #include "array.h"

--- a/ext/io/event/selector/list.h
+++ b/ext/io/event/selector/list.h
@@ -1,6 +1,7 @@
 // Released under the MIT License.
 // Copyright, 2023, by Samuel Williams.
 
+#include <ruby.h>
 #include <stdio.h>
 #include <assert.h>
 

--- a/ext/io/event/selector/pidfd.c
+++ b/ext/io/event/selector/pidfd.c
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <ruby.h>
+
 #include <sys/types.h>
 #include <sys/syscall.h>
 #include <unistd.h>


### PR DESCRIPTION
* Fixes https://github.com/socketry/io-event/issues/88,
  the issue explains it in details.
* `#include "extconf.h"` is redundant and a code smell for missing ruby.h,
  ruby/internal/config.h already does `#include RUBY_EXTCONF_H`.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
