### PR TITLE
fix mingw build

### DIFF
--- a/bake.rb
+++ b/bake.rb
@@ -7,7 +7,7 @@ def build
 	ext_path = File.expand_path("ext", __dir__)
 	
 	Dir.chdir(ext_path) do
-		system("./extconf.rb")
+		system("ruby ./extconf.rb")
 		system("make")
 	end
 end

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -34,7 +34,9 @@
 #endif
 
 #include <time.h>
-#include <sys/wait.h>
+#ifdef HAVE_RB_PROCESS_STATUS_WAIT
+  #include <sys/wait.h>
+#endif
 
 enum IO_Event {
 	IO_EVENT_READABLE = 1,


### PR DESCRIPTION
## Types of Changes
fixes a compile error on mingw
```
compiling ./io/event/event.c
In file included from ./io/event/event.c:22:
./io/event/selector/selector.h:37:10: fatal error: sys/wait.h: No such file or directory
   37 | #include <sys/wait.h>
```
which has been broken by a recent change https://github.com/socketry/io-event/pull/94

also, Windows tests weren't running properly on GHA

- Bug fix.

## Contribution
- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
