### PR TITLE
Expose `#idle_duration` - for experimental load calculation.

### DIFF
--- a/lib/io/event/debug/selector.rb
+++ b/lib/io/event/debug/selector.rb
@@ -33,6 +33,10 @@ module IO::Event
 				@log = log
 			end
 			
+			def idle_duration
+				@selector.idle_duration
+			end
+			
 			def now
 				Process.clock_gettime(Process::CLOCK_MONOTONIC)
 			end

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -31,7 +31,7 @@ class FakeFiber
 end
 
 Selector = Sus::Shared("a selector") do
-	with '.select' do
+	with '#select' do
 		let(:quantum) {0.2}
 		
 		it "can select with 0s timeout" do
@@ -44,6 +44,13 @@ Selector = Sus::Shared("a selector") do
 			expect do
 				selector.select(0.01)
 			end.to have_duration(be <= (0.01 + quantum))
+		end
+	end
+	
+	with '#idle_duration' do
+		it 'can report idle duration' do
+			selector.select(0.01)
+			expect(selector.idle_duration).to be > 0.0
 		end
 	end
 	


### PR DESCRIPTION
Expose the `idle_duration` so that we can compute load metrics.

This feature should be considered experimental and may be changed/removed in the future.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
