### PR TITLE
Fix `IO_Event_Selector_EPoll` -> `KQueue` typo.

### DIFF
--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -371,7 +371,7 @@ VALUE IO_Event_Selector_KQueue_loop(VALUE self) {
 
 VALUE IO_Event_Selector_KQueue_idle_duration(VALUE self) {
 	struct IO_Event_Selector_KQueue *selector = NULL;
-	TypedData_Get_Struct(self, struct IO_Event_Selector_EPoll, &IO_Event_Selector_KQueue_Type, selector);
+	TypedData_Get_Struct(self, struct IO_Event_Selector_KQueue, &IO_Event_Selector_KQueue_Type, selector);
 	
 	double duration = selector->idle_duration.tv_sec + (selector->idle_duration.tv_nsec / 1000000000.0);
 	

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -57,13 +57,13 @@ Selector = Sus::Shared("a selector") do
 	with '#wakeup' do
 		it "can wakeup selector from different thread" do
 			thread = Thread.new do
-				sleep 0.01
+				sleep 0.001
 				selector.wakeup
 			end
 			
 			expect do
-				selector.select(0.1)
-			end.to have_duration(be < 0.1)
+				selector.select(1)
+			end.to have_duration(be < 1)
 		ensure
 			thread.join
 		end
@@ -71,13 +71,13 @@ Selector = Sus::Shared("a selector") do
 		it "can wakeup selector from different thread twice in a row" do
 			2.times do
 				thread = Thread.new do
-					sleep 0.01
+					sleep 0.001
 					selector.wakeup
 				end
 				
 				expect do
-					selector.select(0.1)
-				end.to have_duration(be < 0.1)
+					selector.select(1)
+				end.to have_duration(be < 1)
 			ensure
 				thread.join
 			end


### PR DESCRIPTION
Not sure how this was compiling but it was.

```
./io/event/selector/kqueue.c:374:2: warning: incompatible pointer types assigning to 'struct IO_Event_Selector_KQueue *' from 'struct IO_Event_Selector_EPoll *' [-Wincompatible-pointer-types]
        TypedData_Get_Struct(self, struct IO_Event_Selector_EPoll, &IO_Event_Selector_KQueue_Type, selector);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/samuel/.rubies/ruby-3.3.0/include/ruby-3.3.0/ruby/internal/core/rtypeddata.h:516:13: note: expanded from macro 'TypedData_Get_Struct'
    ((sval) = RBIMPL_CAST((type *)rb_check_typeddata((obj), (data_type))))
            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
