### PR TITLE
Explicitly pull in `<sys/wait.h>` for WNOHANG.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -39,6 +39,8 @@ if have_header('sys/event.h')
 	$srcs << "io/event/selector/kqueue.c"
 end
 
+have_header('sys/wait.h')
+
 have_header('sys/eventfd.h')
 $srcs << "io/event/interrupt.c"
 

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -34,8 +34,9 @@
 #endif
 
 #include <time.h>
-#ifdef HAVE_RB_PROCESS_STATUS_WAIT
-  #include <sys/wait.h>
+
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>
 #endif
 
 enum IO_Event {


### PR DESCRIPTION
Potential fix for <https://github.com/socketry/io-event/issues/99> and <https://github.com/socketry/io-event/issues/98>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
