### PR TITLE
`Timers#after` converts argument to float.

### DIFF
--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -421,7 +421,6 @@ module IO::Event
 				error = nil
 				
 				if duration
-					duration = duration/1.0
 					if duration > 0
 						start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 					end

--- a/lib/io/event/timers.rb
+++ b/lib/io/event/timers.rb
@@ -50,18 +50,19 @@ class IO
 			end
 			
 			# Schedule a block to be called at a specific time in the future.
-			# @parameter time [Time] The time at which the block should be called, relative to {#now}.
+			# @parameter time [Float] The time at which the block should be called, relative to {#now}.
 			def schedule(time, block)
 				handle = Handle.new(time, block)
+				
 				@scheduled << handle
 				
 				return handle
 			end
 			
 			# Schedule a block to be called after a specific time offset, relative to the current time as returned by {#now}.
-			# @parameter offset [Time] The time offset from the current time at which the block should be called.
+			# @parameter offset [#to_f] The time offset from the current time at which the block should be called.
 			def after(offset, &block)
-				schedule(self.now + offset, block)
+				schedule(self.now + offset.to_f, block)
 			end
 			
 			def wait_interval(now = self.now)

--- a/test/io/event/timers.rb
+++ b/test/io/event/timers.rb
@@ -5,6 +5,16 @@
 
 require 'io/event/timers'
 
+class FloatWrapper
+	def initialize(value)
+		@value = value
+	end
+	
+	def to_f
+		@value
+	end
+end
+
 describe IO::Event::Timers do
 	let(:timers) {subject.new}
 	
@@ -65,6 +75,26 @@ describe IO::Event::Timers do
 		end
 		
 		expect(timers.size).to be == 0
+	end
+	
+	with '#schedule' do
+		it "raises an error if given an invalid time" do
+			expect do
+				timers.after(Object.new) {}
+			end.to raise_exception(NoMethodError, message: be =~ /to_f/)
+		end
+		
+		it "converts the offset to a float" do
+			fired = false
+			
+			timers.after(FloatWrapper.new(0.1)) do
+				fired = true
+			end
+			
+			timers.fire(timers.now + 0.15)
+			
+			expect(fired).to be == true
+		end
 	end
 	
 	with '#wait_interval' do


### PR DESCRIPTION
Ensure timer offset is converted to a floating point value.

Fixes <https://github.com/socketry/async/issues/317>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
