### PR TITLE
Fix idle load computation.

### DIFF
--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -420,10 +420,8 @@ module IO::Event
 				duration = 0 unless @ready.empty?
 				error = nil
 				
-				if duration
-					if duration > 0
-						start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-					end
+				if duration&.>(0)
+					start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 				else
 					@idle_duration = 0.0
 				end

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -55,8 +55,13 @@ Selector = Sus::Shared("a selector") do
 	
 	with '#idle_duration' do
 		it 'can report idle duration' do
-			selector.select(0.01)
-			expect(selector.idle_duration).to be > 0.0
+			10.times do
+				selector.select(0.001)
+				expect(selector.idle_duration).to be > 0.0
+				
+				selector.select(0)
+				expect(selector.idle_duration).to be == 0.0
+			end
 		end
 	end
 	


### PR DESCRIPTION
Because the idle duration was not set to zero in some cases, it could create a negative load calculation:

```
@busy_time: 0.0 @idle_time: 0.0 total_time: 0.0
@busy_time: 0.00042687399999863374 @idle_time: 0.0 total_time: 0.00042687399999863374
@busy_time: 0.00048479200000883793 @idle_time: 0.0 total_time: 0.00048479200000883793
@busy_time: 0.0005139570000096683 @idle_time: 0.0 total_time: 0.0005139570000096683
@busy_time: 0.0005577590000029886 @idle_time: 0.010063733000009734 total_time: 0.010621492000012722
@busy_time: 0.0006385590000093089 @idle_time: 0.03013504500000863 total_time: 0.03077360400001794
@busy_time: -0.01935752299996807 @idle_time: 0.05020635700000753 total_time: 0.03084883400003946
@busy_time: -0.03933384799998407 @idle_time: 0.07027766900000643 total_time: 0.030943821000022353
@busy_time: -0.05932057199999008 @idle_time: 0.09034898100000532 total_time: 0.031028409000015245
@busy_time: -0.07932052999998973 @idle_time: 0.11042029300000422 total_time: 0.03109976300001449
@busy_time: -0.09932122999998683 @idle_time: 0.13049160500000312 total_time: 0.031170375000016293
@busy_time: -0.11933091699998499 @idle_time: 0.15056291700000202 total_time: 0.031232000000017024
@busy_time: -0.1393402629999798 @idle_time: 0.17063422900000091 total_time: 0.0312939660000211
@busy_time: -0.15934824699996852 @idle_time: 0.1907055409999998 total_time: 0.03135729400003129
@busy_time: -0.17936314399997855 @idle_time: 0.2107768529999987 total_time: 0.03141370900002016
@busy_time: -0.19938394199996878 @idle_time: 0.2308481649999976 total_time: 0.031464223000028824
@busy_time: -0.21940086299994732 @idle_time: 0.2509194769999965 total_time: 0.03151861400004918
@busy_time: -0.23941894599994384 @idle_time: 0.2709907889999954 total_time: 0.03157184300005156
@busy_time: -0.25943908199994326 @idle_time: 0.2910621009999943 total_time: 0.031623019000051045
@busy_time: -0.27946036099996263 @idle_time: 0.3111334129999932 total_time: 0.031673052000030566
@busy_time: -0.2994807579999872 @idle_time: 0.3312047249999921 total_time: 0.031723967000004905
@busy_time: -0.31950342899997963 @idle_time: 0.351276036999991 total_time: 0.03177260800001136
@busy_time: -0.3395267709999814 @idle_time: 0.3713473489999899 total_time: 0.03182057800000848
@busy_time: -0.35954232899999283 @idle_time: 0.3914186609999888 total_time: 0.031876331999995955
@busy_time: -0.3795625850000022 @idle_time: 0.4114899729999877 total_time: 0.03192738799998551
@busy_time: -0.39958376300000964 @idle_time: 0.4315612849999866 total_time: 0.03197752199997694
```

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
