### PR TITLE
Fix build error with Ruby 3.1 on Windows

### DIFF
--- a/ext/io/event/interrupt.c
+++ b/ext/io/event/interrupt.c
@@ -25,6 +25,13 @@
 
 #include "selector/selector.h"
 
+#ifdef HAVE_RUBY_WIN32_H
+#include <ruby/win32.h>
+#if !defined(HAVE_PIPE) && !defined(pipe)
+#define pipe(p)	rb_w32_pipe(p)
+#endif
+#endif
+
 #ifdef HAVE_SYS_EVENTFD_H
 #include <sys/eventfd.h>
 


### PR DESCRIPTION
Since Ruby 3.2, `pipe` function declaration is provided in https://github.com/ruby/ruby/blob/21c708ee802e1a59901eccc6448e40e8f72189b8/include/ruby/missing.h#L292
However, it does not provided it with Ruby 3.1.

This patch will define `pipe` macro to use proper function due to fix build error.

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes

- Bug fix.

Fix https://github.com/socketry/io-event/issues/111

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
