### PR TITLE
Restore support for `IO::Buffer` in Ruby v3.2.6.

### DIFF
--- a/lib/io/event/support.rb
+++ b/lib/io/event/support.rb
@@ -21,7 +21,8 @@ class IO
 				# https://github.com/ruby/ruby/pull/10778
 				# Specifically "Improvements to IO::Buffer read/write/pread/pwrite."
 				# Missing correct size calculation.
-				return false if RUBY_VERSION >= "3.2.5"
+				# Fixed in https://github.com/ruby/ruby/pull/11779
+				return false if RUBY_VERSION == "3.2.5"
 				
 				IO.const_defined?(:Buffer) and Fiber.respond_to?(:blocking) and IO::Buffer.instance_method(:read).arity == -1
 			end


### PR DESCRIPTION
When https://github.com/ruby/ruby/pull/11777 is merged, we can relax the limitation on support for `IO::Buffer`.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
