### PR TITLE
Dont expose global references needlessly

### DIFF
--- a/ext/io/event/event.c
+++ b/ext/io/event/event.c
@@ -21,17 +21,14 @@
 #include "event.h"
 #include "selector/selector.h"
 
-VALUE IO_Event = Qnil;
-VALUE IO_Event_Selector = Qnil;
-
 void Init_IO_Event(void)
 {
 #ifdef HAVE_RB_EXT_RACTOR_SAFE
 	rb_ext_ractor_safe(true);
 #endif
 	
-	IO_Event = rb_define_module_under(rb_cIO, "Event");
-	IO_Event_Selector = rb_define_module_under(IO_Event, "Selector");
+	VALUE IO_Event = rb_define_module_under(rb_cIO, "Event");
+	VALUE IO_Event_Selector = rb_define_module_under(IO_Event, "Selector");
 	
 	Init_IO_Event_Selector(IO_Event_Selector);
 	

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -34,8 +34,6 @@ enum {
 	DEBUG = 0,
 };
 
-static VALUE IO_Event_Selector_EPoll = Qnil;
-
 enum {EPOLL_MAX_EVENTS = 64};
 
 // This represents an actual fiber waiting for a specific event.
@@ -1037,7 +1035,7 @@ VALUE IO_Event_Selector_EPoll_wakeup(VALUE self) {
 }
 
 void Init_IO_Event_Selector_EPoll(VALUE IO_Event_Selector) {
-	IO_Event_Selector_EPoll = rb_define_class_under(IO_Event_Selector, "EPoll", rb_cObject);
+	VALUE IO_Event_Selector_EPoll = rb_define_class_under(IO_Event_Selector, "EPoll", rb_cObject);
 	
 	rb_define_alloc_func(IO_Event_Selector_EPoll, IO_Event_Selector_EPoll_allocate);
 	rb_define_method(IO_Event_Selector_EPoll, "initialize", IO_Event_Selector_EPoll_initialize, 1);

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -43,8 +43,6 @@ enum {
 #define IO_EVENT_SELECTOR_KQUEUE_USE_INTERRUPT
 #endif
 
-static VALUE IO_Event_Selector_KQueue = Qnil;
-
 enum {KQUEUE_MAX_EVENTS = 64};
 
 // This represents an actual fiber waiting for a specific event.
@@ -1052,7 +1050,7 @@ VALUE IO_Event_Selector_KQueue_wakeup(VALUE self) {
 }
 
 void Init_IO_Event_Selector_KQueue(VALUE IO_Event_Selector) {
-	IO_Event_Selector_KQueue = rb_define_class_under(IO_Event_Selector, "KQueue", rb_cObject);
+	VALUE IO_Event_Selector_KQueue = rb_define_class_under(IO_Event_Selector, "KQueue", rb_cObject);
 	
 	rb_define_alloc_func(IO_Event_Selector_KQueue, IO_Event_Selector_KQueue_allocate);
 	rb_define_method(IO_Event_Selector_KQueue, "initialize", IO_Event_Selector_KQueue_initialize, 1);

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -37,8 +37,6 @@ enum {
 	DEBUG_COMPLETION = 0,
 };
 
-static VALUE IO_Event_Selector_URing = Qnil;
-
 enum {URING_ENTRIES = 64};
 
 #pragma mark - Data Type
@@ -1094,7 +1092,7 @@ VALUE IO_Event_Selector_URing_wakeup(VALUE self) {
 #pragma mark - Native Methods
 
 void Init_IO_Event_Selector_URing(VALUE IO_Event_Selector) {
-	IO_Event_Selector_URing = rb_define_class_under(IO_Event_Selector, "URing", rb_cObject);
+	VALUE IO_Event_Selector_URing = rb_define_class_under(IO_Event_Selector, "URing", rb_cObject);
 	
 	rb_define_alloc_func(IO_Event_Selector_URing, IO_Event_Selector_URing_allocate);
 	rb_define_method(IO_Event_Selector_URing, "initialize", IO_Event_Selector_URing_initialize, 1);


### PR DESCRIPTION
These global variables aren't used anywhere, might as well not expose them, and not need to register them.

But even then, registering them wasn't really necessary because classes defined from C API are pinned and immortal.
