### PR TITLE
Prefer `RB_OBJ_WRITE` over `RB_OBJ_WRITTEN`

### DIFF
--- a/ext/io/event/selector/selector.c
+++ b/ext/io/event/selector/selector.c
@@ -287,8 +287,7 @@ void IO_Event_Selector_queue_push(struct IO_Event_Selector *backend, VALUE fiber
 	waiting->tail = NULL;
 	waiting->flags = IO_EVENT_SELECTOR_QUEUE_INTERNAL;
 	
-	waiting->fiber = fiber;
-	RB_OBJ_WRITTEN(backend->self, Qundef, fiber);
+	RB_OBJ_WRITE(backend->self, &waiting->fiber, fiber);
 	
 	queue_push(backend, waiting);
 }


### PR DESCRIPTION
This is nitpick territory, but when I'm auditing a C extension for write barrier issues, what I do is that I go over all the `VALUE` fields in strucs and for each for them I grep for `->field = `.

This makes it quick to ensure all places where the value is assigned do trigger a write barrier.

With this workflow, `RB_OBJ_WRITTEN` end up causing false positive.
