### PR TITLE
Include free list size in URing memsize

### DIFF
--- a/ext/io/event/selector/list.h
+++ b/ext/io/event/selector/list.h
@@ -71,6 +71,19 @@ inline static void IO_Event_List_free(struct IO_Event_List *node)
 	}
 }
 
+inline static size_t IO_Event_List_memory_size(struct IO_Event_List *list)
+{
+	size_t memsize = 0;
+
+	struct IO_Event_List *node = list->tail;
+	while (node != list) {
+		memsize += sizeof(struct IO_Event_List);
+		node = node->tail;
+	}
+
+	return memsize;
+}
+
 inline static int IO_Event_List_empty(struct IO_Event_List *list)
 {
 	return list->head == list->tail;

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -138,6 +138,7 @@ size_t IO_Event_Selector_URing_Type_size(const void *_selector)
 	
 	return sizeof(struct IO_Event_Selector_URing)
 		+ IO_Event_Array_memory_size(&selector->completions)
+		+ IO_Event_List_memory_size(&selector->free_list)
 	;
 }
 


### PR DESCRIPTION
Not a big deal at all, but I noticed this while auditing write barriers, figured I'd fix it.