### PR TITLE
Add waiting fiber write barrier for all selector implementations.

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -510,7 +510,7 @@ VALUE IO_Event_Selector_EPoll_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 		.events = IO_EVENT_READABLE,
 	};
 	
-	RB_OBJ_WRITTEN(selector->backend.self, Qundef, fiber);
+	RB_OBJ_WRITTEN(self, Qundef, fiber);
 	
 	int result = IO_Event_Selector_EPoll_Waiting_register(selector, 0, descriptor, &waiting);
 	
@@ -571,7 +571,7 @@ VALUE IO_Event_Selector_EPoll_io_wait(VALUE self, VALUE fiber, VALUE io, VALUE e
 		.events = RB_NUM2INT(events),
 	};
 	
-	RB_OBJ_WRITTEN(selector->backend.self, Qundef, fiber);
+	RB_OBJ_WRITTEN(self, Qundef, fiber);
 	
 	int result = IO_Event_Selector_EPoll_Waiting_register(selector, io, descriptor, &waiting);
 	
@@ -671,6 +671,8 @@ VALUE IO_Event_Selector_EPoll_io_read(VALUE self, VALUE fiber, VALUE io, VALUE b
 		.offset = offset,
 	};
 	
+	RB_OBJ_WRITTEN(self, Qundef, fiber);
+	
 	return rb_ensure(io_read_loop, (VALUE)&io_read_arguments, io_read_ensure, (VALUE)&io_read_arguments);
 }
 
@@ -766,6 +768,8 @@ VALUE IO_Event_Selector_EPoll_io_write(VALUE self, VALUE fiber, VALUE io, VALUE 
 		.length = length,
 		.offset = offset,
 	};
+	
+	RB_OBJ_WRITTEN(self, Qundef, fiber);
 	
 	return rb_ensure(io_write_loop, (VALUE)&io_write_arguments, io_write_ensure, (VALUE)&io_write_arguments);
 }

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -505,6 +505,8 @@ VALUE IO_Event_Selector_KQueue_process_wait(VALUE self, VALUE fiber, VALUE _pid,
 		.events = IO_EVENT_EXIT,
 	};
 	
+	RB_OBJ_WRITTEN(self, Qundef, fiber);
+	
 	struct process_wait_arguments process_wait_arguments = {
 		.selector = selector,
 		.waiting = &waiting,
@@ -567,6 +569,8 @@ VALUE IO_Event_Selector_KQueue_io_wait(VALUE self, VALUE fiber, VALUE io, VALUE 
 		.fiber = fiber,
 		.events = RB_NUM2INT(events),
 	};
+	
+	RB_OBJ_WRITTEN(self, Qundef, fiber);
 	
 	int result = IO_Event_Selector_KQueue_Waiting_register(selector, descriptor, &waiting);
 	if (result == -1) {
@@ -670,6 +674,8 @@ VALUE IO_Event_Selector_KQueue_io_read(VALUE self, VALUE fiber, VALUE io, VALUE 
 		.length = length,
 		.offset = offset,
 	};
+	
+	RB_OBJ_WRITTEN(self, Qundef, fiber);
 	
 	return rb_ensure(io_read_loop, (VALUE)&io_read_arguments, io_read_ensure, (VALUE)&io_read_arguments);
 }
@@ -776,6 +782,8 @@ VALUE IO_Event_Selector_KQueue_io_write(VALUE self, VALUE fiber, VALUE io, VALUE
 		.length = length,
 		.offset = offset,
 	};
+	
+	RB_OBJ_WRITTEN(self, Qundef, fiber);
 	
 	return rb_ensure(io_write_loop, (VALUE)&io_write_arguments, io_write_ensure, (VALUE)&io_write_arguments);
 }

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -487,6 +487,8 @@ VALUE IO_Event_Selector_URing_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 		.fiber = fiber,
 	};
 	
+	RB_OBJ_WRITTEN(self, Qundef, fiber);
+	
 	struct IO_Event_Selector_URing_Completion *completion = IO_Event_Selector_URing_Completion_acquire(selector, &waiting);
 	
 	struct process_wait_arguments process_wait_arguments = {
@@ -590,6 +592,8 @@ VALUE IO_Event_Selector_URing_io_wait(VALUE self, VALUE fiber, VALUE io, VALUE e
 		.fiber = fiber,
 	};
 	
+	RB_OBJ_WRITTEN(self, Qundef, fiber);
+	
 	struct IO_Event_Selector_URing_Completion *completion = IO_Event_Selector_URing_Completion_acquire(selector, &waiting);
 	
 	struct io_uring_sqe *sqe = io_get_sqe(selector);
@@ -682,6 +686,8 @@ io_read(struct IO_Event_Selector_URing *selector, VALUE fiber, int descriptor, c
 	struct IO_Event_Selector_URing_Waiting waiting = {
 		.fiber = fiber,
 	};
+	
+	RB_OBJ_WRITTEN(selector->backend.self, Qundef, fiber);
 	
 	IO_Event_Selector_URing_Completion_acquire(selector, &waiting);
 	
@@ -844,6 +850,8 @@ io_write(struct IO_Event_Selector_URing *selector, VALUE fiber, int descriptor, 
 	struct IO_Event_Selector_URing_Waiting waiting = {
 		.fiber = fiber,
 	};
+	
+	RB_OBJ_WRITTEN(selector->backend.self, Qundef, fiber);
 	
 	IO_Event_Selector_URing_Completion_acquire(selector, &waiting);
 	

--- a/test/io/event/selector/allocation.rb
+++ b/test/io/event/selector/allocation.rb
@@ -12,7 +12,11 @@ IO::Event::Selector.constants.each do |name|
 		@selector = klass.new(Fiber.current)
 		
 		# Force the selector to be old generation:
-		Process.warmup
+		if Process.respond_to?(:warmup)
+			Process.warmup
+		else
+			3.times{GC.start}
+		end
 	end
 	
 	after do

--- a/test/io/event/selector/allocation.rb
+++ b/test/io/event/selector/allocation.rb
@@ -25,6 +25,8 @@ IO::Event::Selector.constants.each do |name|
 	
 	describe(klass, unique: name) do
 		it "can allocate and deallocate multiple times" do
+			skip_if_ruby_platform(/mswin|mingw|cygwin/)
+			
 			pipes = 10.times.collect{IO.pipe}
 			
 			# This test can hang if write barriers are incorrectly implemented.


### PR DESCRIPTION
Fixes <https://github.com/socketry/io-event/issues/121>

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
