### PR TITLE
Add write barriers to `IO_Event_Selector_resume/_raise`.

### DIFF
--- a/ext/io/event/selector/selector.c
+++ b/ext/io/event/selector/selector.c
@@ -233,6 +233,8 @@ VALUE IO_Event_Selector_resume(struct IO_Event_Selector *backend, int argc, VALU
 		.fiber = rb_fiber_current()
 	};
 	
+	RB_OBJ_WRITTEN(backend->self, Qundef, waiting.fiber);
+	
 	queue_push(backend, &waiting);
 	
 	struct wait_and_transfer_arguments arguments = {
@@ -265,6 +267,8 @@ VALUE IO_Event_Selector_raise(struct IO_Event_Selector *backend, int argc, VALUE
 		.flags = IO_EVENT_SELECTOR_QUEUE_FIBER,
 		.fiber = rb_fiber_current()
 	};
+	
+	RB_OBJ_WRITTEN(backend->self, Qundef, waiting.fiber);
 	
 	queue_push(backend, &waiting);
 	


### PR DESCRIPTION
Possible fix for <https://github.com/socketry/io-event/issues/123>.

Even thought there is a pointer on the stack, it's a pointer to itself (`rb_fiber_current`) and thus a circular reference, thus entirely possible for the GC to clean up this fiber.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
