### PR TITLE
Validate selector support at run time.

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -1035,7 +1035,7 @@ VALUE IO_Event_Selector_EPoll_wakeup(VALUE self) {
 	return Qfalse;
 }
 
-int IO_Event_Selector_EPoll_supported_p() {
+static int IO_Event_Selector_EPoll_supported_p(void) {
 	int fd = epoll_create1(EPOLL_CLOEXEC);
 	
 	if (fd < 0) {

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -1039,7 +1039,9 @@ static int IO_Event_Selector_EPoll_supported_p(void) {
 	int fd = epoll_create1(EPOLL_CLOEXEC);
 	
 	if (fd < 0) {
-			return 0;
+		rb_warn("epoll_create1() was available at compile time but failed at run time: %s\n", strerror(errno));
+		
+		return 0;
 	}
 	
 	close(fd);

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -1035,7 +1035,23 @@ VALUE IO_Event_Selector_EPoll_wakeup(VALUE self) {
 	return Qfalse;
 }
 
+int IO_Event_Selector_EPoll_supported_p() {
+	int fd = epoll_create1(EPOLL_CLOEXEC);
+	
+	if (fd < 0) {
+			return 0;
+	}
+	
+	close(fd);
+	
+	return 1;
+}
+
 void Init_IO_Event_Selector_EPoll(VALUE IO_Event_Selector) {
+	if (!IO_Event_Selector_EPoll_supported_p()) {
+		return;
+	}
+	
 	VALUE IO_Event_Selector_EPoll = rb_define_class_under(IO_Event_Selector, "EPoll", rb_cObject);
 	
 	rb_define_alloc_func(IO_Event_Selector_EPoll, IO_Event_Selector_EPoll_allocate);

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -1046,7 +1046,7 @@ VALUE IO_Event_Selector_KQueue_wakeup(VALUE self) {
 }
 
 
-int IO_Event_Selector_KQueue_supported_p() {
+static int IO_Event_Selector_KQueue_supported_p(void) {
 	int fd = kqueue();
 	
 	if (fd < 0) {

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -1045,7 +1045,24 @@ VALUE IO_Event_Selector_KQueue_wakeup(VALUE self) {
 	return Qfalse;
 }
 
+
+int IO_Event_Selector_KQueue_supported_p() {
+	int fd = kqueue();
+	
+	if (fd < 0) {
+			return 0;
+	}
+	
+	close(fd);
+	
+	return 1;
+}
+
 void Init_IO_Event_Selector_KQueue(VALUE IO_Event_Selector) {
+	if (!IO_Event_Selector_KQueue_supported_p()) {
+			return;
+	}
+	
 	VALUE IO_Event_Selector_KQueue = rb_define_class_under(IO_Event_Selector, "KQueue", rb_cObject);
 	
 	rb_define_alloc_func(IO_Event_Selector_KQueue, IO_Event_Selector_KQueue_allocate);

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -1050,7 +1050,9 @@ static int IO_Event_Selector_KQueue_supported_p(void) {
 	int fd = kqueue();
 	
 	if (fd < 0) {
-			return 0;
+		rb_warn("kqueue() was available at compile time but failed at run time: %s\n", strerror(errno));
+		
+		return 0;
 	}
 	
 	close(fd);
@@ -1060,7 +1062,7 @@ static int IO_Event_Selector_KQueue_supported_p(void) {
 
 void Init_IO_Event_Selector_KQueue(VALUE IO_Event_Selector) {
 	if (!IO_Event_Selector_KQueue_supported_p()) {
-			return;
+		return;
 	}
 	
 	VALUE IO_Event_Selector_KQueue = rb_define_class_under(IO_Event_Selector, "KQueue", rb_cObject);

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -1177,9 +1177,11 @@ VALUE IO_Event_Selector_URing_wakeup(VALUE self) {
 
 static int IO_Event_Selector_URing_supported_p(void) {
 	struct io_uring ring;
-	int result = io_uring_queue_init(1, &ring, 0);
+	int result = io_uring_queue_init(32, &ring, 0);
 	
 	if (result < 0) {
+		rb_warn("io_uring_queue_init() was available at compile time but failed at run time: %s\n", strerror(-result));
+		
 		return 0;
 	}
 	

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -1175,7 +1175,24 @@ VALUE IO_Event_Selector_URing_wakeup(VALUE self) {
 
 #pragma mark - Native Methods
 
+int IO_Event_Selector_URing_supported_p() {
+	struct io_uring ring;
+	int result = io_uring_queue_init(1, &ring, 0);
+	
+	if (result < 0) {
+		return 0;
+	}
+	
+	io_uring_queue_exit(&ring);
+	
+	return 1;
+}
+
 void Init_IO_Event_Selector_URing(VALUE IO_Event_Selector) {
+	if (!IO_Event_Selector_URing_supported_p()) {
+		return;
+	}
+	
 	VALUE IO_Event_Selector_URing = rb_define_class_under(IO_Event_Selector, "URing", rb_cObject);
 	
 	rb_define_alloc_func(IO_Event_Selector_URing, IO_Event_Selector_URing_allocate);

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -1175,7 +1175,7 @@ VALUE IO_Event_Selector_URing_wakeup(VALUE self) {
 
 #pragma mark - Native Methods
 
-int IO_Event_Selector_URing_supported_p() {
+static int IO_Event_Selector_URing_supported_p(void) {
 	struct io_uring ring;
 	int result = io_uring_queue_init(1, &ring, 0);
 	

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
   - `IO::Event::Profiler` is moved to dedicated gem: [fiber-profiler](https://github.com/socketry/fiber-profiler).
+  - Perform runtime checks for native selectors to ensure they are supported in the current environment. While compile-time checks determine availability, restrictions like seccomp and SELinux may still prevent them from working.
 
 ## v1.9.0
 


### PR DESCRIPTION
While `io_uring`, `epoll`, and `kqueue` may be available at compile time, their actual support at runtime is not guaranteed. Various factors, such as kernel configuration, security policies (seccomp, AppArmor, SELinux), or resource limits, may prevent them from working as expected.

This PR introduces explicit runtime checks for each event selector, ensuring that we only define the corresponding constant when the selector is truly available. 

While it would be possible to defer these checks until selector creation, this approach follows the existing pattern of defining constants at initialization time, keeping the implementation consistent with the current interface.

### Changes

- Adds `IO_Event_Selector_URing_supported_p()`, `IO_Event_Selector_EPoll_supported_p()`, and `IO_Event_Selector_KQueue_supported_p()`, which attempt to create a minimal instance of each selector to verify availability.
- Updates `Init_IO_Event_Selector_*()` to only define the corresponding selector if the runtime check passes.
- Ensures that systems where a selector is unavailable fail gracefully without requiring conditional compilation.

### Why?

- Prevents runtime failures when attempting to use an unavailable selector.
- Improves compatibility with sandboxed environments, containers, and restricted runtime configurations.
- Aligns with existing interface patterns by conditionally defining support constants.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
