### PR TITLE
Use append_cflags instead of modifying CFLAGS directly

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -14,12 +14,12 @@ extension_name = "IO_Event"
 
 # dir_config(extension_name)
 
-$CFLAGS << " -Wall -Wno-unknown-pragmas -std=c99"
+append_cflags(["-Wall", "-Wno-unknown-pragmas", "-std=c99"])
 
 if ENV.key?("RUBY_DEBUG")
 	$stderr.puts "Enabling debug mode..."
-	
-	$CFLAGS << " -DRUBY_DEBUG -O0"
+
+	append_cflags(["-DRUBY_DEBUG", "-O0"])
 end
 
 $srcs = ["io/event/event.c", "io/event/time.c", "io/event/fiber.c", "io/event/selector/selector.c"]
@@ -32,7 +32,7 @@ have_func("&rb_fiber_transfer")
 if have_library("uring") and have_header("liburing.h")
 	# We might want to consider using this in the future:
 	# have_func("io_uring_submit_and_wait_timeout", "liburing.h")
-	
+
 	$srcs << "io/event/selector/uring.c"
 end
 
@@ -59,9 +59,9 @@ have_header("ruby/io/buffer.h")
 
 if ENV.key?("RUBY_SANITIZE")
 	$stderr.puts "Enabling sanitizers..."
-	
+
 	# Add address and undefined behaviour sanitizers:
-	$CFLAGS << " -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer"
+	append_cflags(["-fsanitize=address", "-fsanitize=undefined", "-fno-omit-frame-pointer"])
 	$LDFLAGS << " -fsanitize=address -fsanitize=undefined"
 end
 


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

Linux system with latest GCC 15 can't compile this gem. See more #136

## Types of Changes
Use append_cflags instead of modifying CFLAGS directly 

According to this thread
https://inbox.vuxu.org/ruby-core/redmine.issue-21290.20250428190637.58020@ruby-lang.org/T/

`ed25519` gem had a [similar issue](https://github.com/RubyCrypto/ed25519/issues/44), and it was resolved by migrating to append_cflags.
https://github.com/RubyCrypto/ed25519/commit/c1ee0e0cd5807048d2382feba3d6ad8aad850b0c

Let's move this gem to append_cflags as well. This approach is recommended over modifying CFLAGS since it ensures compatibility across different build environments by checking whether the flag is acceptable, and should not affect most systems. 

In the meantime, it appears that Nobu has merged a wider fix to ruby itself. But this improvement will not hurt in the long term.

## Testing

Building this branch with `bake build` works on my machine. At the same time, `main` branch is failing.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
