### PR TITLE
Forward `**options` in `raise`.

### DIFF
--- a/examples/scheduler/scheduler.rb
+++ b/examples/scheduler/scheduler.rb
@@ -58,8 +58,8 @@ class IO
 				@selector.push(fiber)
 			end
 			
-			def raise(*arguments)
-				@selector.raise(*arguments)
+			def raise(*arguments, **options)
+				@selector.raise(*arguments, **options)
 			end
 			
 			def resume(fiber, *arguments)

--- a/lib/io/event/debug/selector.rb
+++ b/lib/io/event/debug/selector.rb
@@ -116,9 +116,9 @@ module IO::Event
 			#
 			# @parameter fiber [Fiber] The fiber to raise the exception on.
 			# @parameter arguments [Array] The arguments to use when raising the exception.
-			def raise(fiber, *arguments)
+			def raise(fiber, *arguments, **options)
 				log("Raising exception on fiber #{fiber.inspect} with #{arguments.inspect}")
-				@selector.raise(fiber, *arguments)
+				@selector.raise(fiber, *arguments, **options)
 			end
 			
 			# Check if the selector is ready.

--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -98,11 +98,11 @@ module IO::Event
 			end
 			
 			# Transfer to the given fiber and raise an exception. Put the current fiber into the ready list.
-			def raise(fiber, *arguments)
+			def raise(fiber, *arguments, **options)
 				optional = Optional.new(Fiber.current)
 				@ready.push(optional)
 				
-				fiber.raise(*arguments)
+				fiber.raise(*arguments, **options)
 			ensure
 				optional.nullify
 			end


### PR DESCRIPTION
Ruby 3.5 will explicitly support `cause:` to `Thread#raise` and `Fiber#raise`.

While working on this in Async, I found the compiled code path is fine, but the pure Ruby code path is not, because keyword arguments get converted to positional arguments.

https://github.com/socketry/async/pull/388

This ensures we pass through `**options` correctly.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
