### PR TITLE
Use `io_uring_prep_waitid` for `process_wait` in URing selector.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -32,9 +32,7 @@ have_func("rb_ext_ractor_safe")
 have_func("&rb_fiber_transfer")
 
 if have_library("uring") and have_header("liburing.h")
-	# We might want to consider using this in the future:
-	# have_func("io_uring_submit_and_wait_timeout", "liburing.h")
-	
+	have_func("io_uring_prep_waitid", "liburing.h")
 	$srcs << "io/event/selector/uring.c"
 end
 
@@ -52,6 +50,7 @@ have_header("sys/eventfd.h")
 $srcs << "io/event/interrupt.c"
 
 have_func("rb_io_descriptor")
+have_func("&rb_process_status_new")
 have_func("&rb_process_status_wait")
 have_func("rb_fiber_current")
 have_func("&rb_fiber_raise")

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -50,7 +50,6 @@ have_header("sys/eventfd.h")
 $srcs << "io/event/interrupt.c"
 
 have_func("rb_io_descriptor")
-have_func("&rb_process_status_new")
 have_func("&rb_process_status_wait")
 have_func("rb_fiber_current")
 have_func("&rb_fiber_raise")

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -15,9 +15,18 @@
 
 #include "../interrupt.h"
 
-#include "pidfd.c"
-
 #include <linux/version.h>
+
+// `io_uring` support for `IORING_OP_WAITID` was introduced in Linux 6.7. When
+// available, we use it to wait for process exit directly in the ring, instead
+// of polling on a pidfd.
+#if defined(HAVE_IO_URING_PREP_WAITID) && (LINUX_VERSION_CODE >= KERNEL_VERSION(6,7,0))
+#define IO_EVENT_SELECTOR_URING_USE_WAITID
+#endif
+
+#ifndef IO_EVENT_SELECTOR_URING_USE_WAITID
+#include "pidfd.c"
+#endif
 
 enum {
 	DEBUG = 0,
@@ -500,17 +509,28 @@ struct io_uring_sqe * io_get_sqe(struct IO_Event_Selector_URing *selector) {
 
 #pragma mark - Process.wait
 
-#if defined(HAVE_IO_URING_PREP_WAITID) && defined(HAVE__RB_PROCESS_STATUS_NEW)
-#define USE_WAITID
-
-inline idtype_t waitid_type(int pid) {
-	switch (pid) {
-		case -1:
-			return P_ALL;
-		case 0:
-			return P_PGID;
-		default:
-			return P_PID;
+#ifdef IO_EVENT_SELECTOR_URING_USE_WAITID
+// Translate a Ruby/`waitpid`-style pid into the `waitid(2)` idtype and id,
+// mirroring the semantics of `waitpid(2)`:
+//
+//   pid == -1  -> any child                                  (P_ALL)
+//   pid ==  0  -> any child in the caller's process group    (P_PGID, id 0; Linux >= 5.4)
+//   pid <  -1  -> any child in process group |pid|           (P_PGID)
+//   pid >   0  -> the specific child                         (P_PID)
+//
+static inline idtype_t process_waitid_type(pid_t pid, id_t *id) {
+	if (pid == -1) {
+		*id = 0;
+		return P_ALL;
+	} else if (pid == 0) {
+		*id = 0;
+		return P_PGID;
+	} else if (pid < -1) {
+		*id = (id_t)(-pid);
+		return P_PGID;
+	} else {
+		*id = (id_t)pid;
+		return P_PID;
 	}
 }
 #endif
@@ -521,12 +541,12 @@ struct process_wait_arguments {
 	
 	pid_t pid;
 	int flags;
-
-	#ifdef USE_WAITID
-	siginfo_t infop;
-	#else
+	
+#ifdef IO_EVENT_SELECTOR_URING_USE_WAITID
+	siginfo_t siginfo;
+#else
 	int descriptor;
-	#endif
+#endif
 };
 
 static
@@ -535,29 +555,34 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	
 	IO_Event_Selector_loop_yield(&arguments->selector->backend);
 	
-	#ifdef USE_WAITID
-	if (DEBUG) printf("waitid result: %d pid: %d status: %d\n", 
-		arguments->waiting->result,
-		arguments->infop.si_pid,
-		arguments->infop.si_status
-	);
-	return rb_process_status_new(arguments->infop.si_pid, arguments->infop.si_status, 0);
-	#else
+#ifdef IO_EVENT_SELECTOR_URING_USE_WAITID
+	int32_t result = arguments->waiting->result;
+	if (result < 0) {
+		rb_syserr_fail(-result, "IO_Event_Selector_URing_process_wait:io_uring_prep_waitid");
+	}
+	
+	if (DEBUG) fprintf(stderr, "waitid result=%d pid=%d code=%d status=%d\n", result, arguments->siginfo.si_pid, arguments->siginfo.si_code, arguments->siginfo.si_status);
+	
+	// We waited with `WNOWAIT`, so the child has not been reaped yet. `si_pid`
+	// tells us exactly which child changed state (important when waiting for any
+	// child, e.g. pid -1). Reap it to obtain a correct `Process::Status`:
+	return IO_Event_Selector_process_status_wait(arguments->siginfo.si_pid, arguments->flags);
+#else
 	if (arguments->waiting->result) {
 		return IO_Event_Selector_process_status_wait(arguments->pid, arguments->flags);
 	} else {
 		return Qfalse;
 	}
-	#endif
+#endif
 }
 
 static
 VALUE process_wait_ensure(VALUE _arguments) {
 	struct process_wait_arguments *arguments = (struct process_wait_arguments *)_arguments;
 	
-	#ifndef USE_WAITID
+#ifndef IO_EVENT_SELECTOR_URING_USE_WAITID
 	close(arguments->descriptor);
-	#endif
+#endif
 	
 	IO_Event_Selector_URing_Waiting_cancel(arguments->waiting);
 	
@@ -571,13 +596,13 @@ VALUE IO_Event_Selector_URing_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 	pid_t pid = NUM2PIDT(_pid);
 	int flags = NUM2INT(_flags);
 	
-	#ifndef USE_WAITID
+#ifndef IO_EVENT_SELECTOR_URING_USE_WAITID
 	int descriptor = pidfd_open(pid, 0);
 	if (descriptor < 0) {
 		rb_syserr_fail(errno, "IO_Event_Selector_URing_process_wait:pidfd_open");
 	}
 	rb_update_max_fd(descriptor);
-	#endif
+#endif
 	
 	struct IO_Event_Selector_URing_Waiting waiting = {
 		.fiber = fiber,
@@ -592,23 +617,26 @@ VALUE IO_Event_Selector_URing_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 		.waiting = &waiting,
 		.pid = pid,
 		.flags = flags,
-		#ifdef USE_WAITID
-		.infop = { .si_pid = 0, .si_status = 0 }
-		#else
-		.descriptor = descriptor
-		#endif
+#ifdef IO_EVENT_SELECTOR_URING_USE_WAITID
+		.siginfo = {0},
+#else
+		.descriptor = descriptor,
+#endif
 	};
 	
 	struct io_uring_sqe *sqe = io_get_sqe(selector);
-
-	#ifdef USE_WAITID
-	if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_process_wait:io_uring_prep_waitid(%p)\n", (void*)fiber);
-	if (DEBUG) printf("waitid pid: %d flags: %d\n", pid, flags);
-	io_uring_prep_waitid(sqe, waitid_type(pid), pid, &process_wait_arguments.infop, WEXITED, 0);
-	#else
+	
+#ifdef IO_EVENT_SELECTOR_URING_USE_WAITID
+	id_t id;
+	idtype_t idtype = process_waitid_type(pid, &id);
+	if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_process_wait:io_uring_prep_waitid(fiber=%p, idtype=%d, id=%d, flags=%d)\n", (void*)fiber, idtype, (int)id, flags);
+	// `WNOWAIT` leaves the child in a waitable state so we can reap it with
+	// `rb_process_status_wait` afterwards and build a correct `Process::Status`:
+	io_uring_prep_waitid(sqe, idtype, id, &process_wait_arguments.siginfo, WEXITED | WNOWAIT, 0);
+#else
 	if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_process_wait:io_uring_prep_poll_add(%p)\n", (void*)fiber);
 	io_uring_prep_poll_add(sqe, descriptor, POLLIN|POLLHUP|POLLERR);
-	#endif
+#endif
 	io_uring_sqe_set_data(sqe, completion);
 	io_uring_submit_pending(selector);
 	

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -17,9 +17,7 @@
 
 #include <linux/version.h>
 
-// `io_uring` support for `IORING_OP_WAITID` was introduced in Linux 6.7. When
-// available, we use it to wait for process exit directly in the ring, instead
-// of polling on a pidfd.
+// `io_uring` support for `IORING_OP_WAITID` was introduced in Linux 6.7. When available, we use it to wait for process exit directly in the ring, instead of polling on a pidfd.
 #if defined(HAVE_IO_URING_PREP_WAITID) && (LINUX_VERSION_CODE >= KERNEL_VERSION(6,7,0))
 #define IO_EVENT_SELECTOR_URING_USE_WAITID
 #endif

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -500,13 +500,33 @@ struct io_uring_sqe * io_get_sqe(struct IO_Event_Selector_URing *selector) {
 
 #pragma mark - Process.wait
 
+#if defined(HAVE_IO_URING_PREP_WAITID) && defined(HAVE__RB_PROCESS_STATUS_NEW)
+#define USE_WAITID
+
+inline idtype_t waitid_type(int pid) {
+	switch (pid) {
+		case -1:
+			return P_ALL;
+		case 0:
+			return P_PGID;
+		default:
+			return P_PID;
+	}
+}
+#endif
+
 struct process_wait_arguments {
 	struct IO_Event_Selector_URing *selector;
 	struct IO_Event_Selector_URing_Waiting *waiting;
 	
 	pid_t pid;
 	int flags;
+
+	#ifdef USE_WAITID
+	siginfo_t infop;
+	#else
 	int descriptor;
+	#endif
 };
 
 static
@@ -515,18 +535,29 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	
 	IO_Event_Selector_loop_yield(&arguments->selector->backend);
 	
+	#ifdef USE_WAITID
+	if (DEBUG) printf("waitid result: %d pid: %d status: %d\n", 
+		arguments->waiting->result,
+		arguments->infop.si_pid,
+		arguments->infop.si_status
+	);
+	return rb_process_status_new(arguments->infop.si_pid, arguments->infop.si_status, 0);
+	#else
 	if (arguments->waiting->result) {
 		return IO_Event_Selector_process_status_wait(arguments->pid, arguments->flags);
 	} else {
 		return Qfalse;
 	}
+	#endif
 }
 
 static
 VALUE process_wait_ensure(VALUE _arguments) {
 	struct process_wait_arguments *arguments = (struct process_wait_arguments *)_arguments;
 	
+	#ifndef USE_WAITID
 	close(arguments->descriptor);
+	#endif
 	
 	IO_Event_Selector_URing_Waiting_cancel(arguments->waiting);
 	
@@ -540,11 +571,13 @@ VALUE IO_Event_Selector_URing_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 	pid_t pid = NUM2PIDT(_pid);
 	int flags = NUM2INT(_flags);
 	
+	#ifndef USE_WAITID
 	int descriptor = pidfd_open(pid, 0);
 	if (descriptor < 0) {
 		rb_syserr_fail(errno, "IO_Event_Selector_URing_process_wait:pidfd_open");
 	}
 	rb_update_max_fd(descriptor);
+	#endif
 	
 	struct IO_Event_Selector_URing_Waiting waiting = {
 		.fiber = fiber,
@@ -559,12 +592,23 @@ VALUE IO_Event_Selector_URing_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 		.waiting = &waiting,
 		.pid = pid,
 		.flags = flags,
-		.descriptor = descriptor,
+		#ifdef USE_WAITID
+		.infop = { .si_pid = 0, .si_status = 0 }
+		#else
+		.descriptor = descriptor
+		#endif
 	};
 	
-	if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_process_wait:io_uring_prep_poll_add(%p)\n", (void*)fiber);
 	struct io_uring_sqe *sqe = io_get_sqe(selector);
+
+	#ifdef USE_WAITID
+	if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_process_wait:io_uring_prep_waitid(%p)\n", (void*)fiber);
+	if (DEBUG) printf("waitid pid: %d flags: %d\n", pid, flags);
+	io_uring_prep_waitid(sqe, waitid_type(pid), pid, &process_wait_arguments.infop, WEXITED, 0);
+	#else
+	if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_process_wait:io_uring_prep_poll_add(%p)\n", (void*)fiber);
 	io_uring_prep_poll_add(sqe, descriptor, POLLIN|POLLHUP|POLLERR);
+	#endif
 	io_uring_sqe_set_data(sqe, completion);
 	io_uring_submit_pending(selector);
 	

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -508,8 +508,7 @@ struct io_uring_sqe * io_get_sqe(struct IO_Event_Selector_URing *selector) {
 #pragma mark - Process.wait
 
 #ifdef IO_EVENT_SELECTOR_URING_USE_WAITID
-// Translate a Ruby/`waitpid`-style pid into the `waitid(2)` idtype and id,
-// mirroring the semantics of `waitpid(2)`:
+// Translate a Ruby/`waitpid`-style pid into the `waitid(2)` idtype and id, mirroring the semantics of `waitpid(2)`:
 //
 //   pid == -1  -> any child                                  (P_ALL)
 //   pid ==  0  -> any child in the caller's process group    (P_PGID, id 0; Linux >= 5.4)

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -563,9 +563,7 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	
 	if (DEBUG) fprintf(stderr, "waitid result=%d pid=%d code=%d status=%d\n", result, arguments->siginfo.si_pid, arguments->siginfo.si_code, arguments->siginfo.si_status);
 	
-	// We waited with `WNOWAIT`, so the child has not been reaped yet. `si_pid`
-	// tells us exactly which child changed state (important when waiting for any
-	// child, e.g. pid -1). Reap it to obtain a correct `Process::Status`:
+	// We waited with `WNOWAIT`, so the child has not been reaped yet. `si_pid` tells us exactly which child changed state (important when waiting for any child, e.g. pid -1). Reap it to obtain a correct `Process::Status`:
 	return IO_Event_Selector_process_status_wait(arguments->siginfo.si_pid, arguments->flags);
 #else
 	if (arguments->waiting->result) {

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -625,8 +625,7 @@ VALUE IO_Event_Selector_URing_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 	id_t id;
 	idtype_t idtype = process_waitid_type(pid, &id);
 	if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_process_wait:io_uring_prep_waitid(fiber=%p, idtype=%d, id=%d, flags=%d)\n", (void*)fiber, idtype, (int)id, flags);
-	// `WNOWAIT` leaves the child in a waitable state so we can reap it with
-	// `rb_process_status_wait` afterwards and build a correct `Process::Status`:
+	// `WNOWAIT` leaves the child in a waitable state so we can reap it with `rb_process_status_wait` afterwards and build a correct `Process::Status`:
 	io_uring_prep_waitid(sqe, idtype, id, &process_wait_arguments.siginfo, WEXITED | WNOWAIT, 0);
 #else
 	if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_process_wait:io_uring_prep_poll_add(%p)\n", (void*)fiber);

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Use `io_uring_prep_waitid` for `process_wait` in the `URing` selector (Linux 6.7+), waiting for child exit directly in the ring instead of polling on a `pidfd`. The child is reaped via `rb_process_status_wait` (using `WEXITED | WNOWAIT`) to construct a correct `Process::Status`, and `process_wait(-1, ...)` / `process_wait(0, ...)` are now supported.
+
 ## v1.18.0
 
   - **Fixed**: Avoid entering a blocking native selector wait when an interrupt is already pending for the current thread.

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -676,34 +676,6 @@ Selector = Sus::Shared("a selector") do
 			expect(result1).to be(:success?)
 			expect(result2).to be(:success?)
 		end
-		
-		it "can wait for any child process" do
-			skip("This test works only on URing selector") if !selector.is_a?(IO::Event::Selector::URing)
-			
-			result1 = result2 = nil
-			pids = []
-			
-			fiber = Fiber.new do
-				pid1 = Process.spawn("sleep 0")
-				pid2 = Process.spawn("sleep 0")
-				pids << pid1 << pid2
-				
-				result1 = selector.process_wait(Fiber.current, -1, 0)
-				result2 = selector.process_wait(Fiber.current, -1, 0)
-			end
-			
-			fiber.transfer
-			
-			while fiber.alive?
-				selector.select(0)
-			end
-			
-			expect(result1).to be(:success?)
-			expect(result2).to be(:success?)
-			
-			result_pids = [result1, result2].map(&:pid).sort
-			expect(result_pids).to be == pids.sort
-		end
 	end
 	
 	with "#resume" do

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -676,6 +676,34 @@ Selector = Sus::Shared("a selector") do
 			expect(result1).to be(:success?)
 			expect(result2).to be(:success?)
 		end
+		
+		it "can wait for any child process" do
+			skip("This test works only on URing selector") if !selector.is_a?(IO::Event::Selector::URing)
+			
+			result1 = result2 = nil
+			pids = []
+			
+			fiber = Fiber.new do
+				pid1 = Process.spawn("sleep 0")
+				pid2 = Process.spawn("sleep 0")
+				pids << pid1 << pid2
+				
+				result1 = selector.process_wait(Fiber.current, -1, 0)
+				result2 = selector.process_wait(Fiber.current, -1, 0)
+			end
+			
+			fiber.transfer
+			
+			while fiber.alive?
+				selector.select(0)
+			end
+			
+			expect(result1).to be(:success?)
+			expect(result2).to be(:success?)
+			
+			result_pids = [result1, result2].map(&:pid).sort
+			expect(result_pids).to be == pids.sort
+		end
 	end
 	
 	with "#resume" do

--- a/test/io/event/selector/process_io.rb
+++ b/test/io/event/selector/process_io.rb
@@ -38,6 +38,33 @@ ProcessIO = Sus::Shared("process io") do
 		
 		expect(result.success?).to be == true
 	end
+
+	it "can wait for a process which has terminated already" do
+		result = nil
+		
+		fiber = Fiber.new do
+			input, output = IO.pipe
+			
+			# For some reason, sleep 0.1 here is very unreliable...?
+			pid = Process.spawn("true", out: output)
+			output.close
+			
+			# Internally, this should generate POLLHUP, which is what we want to test:
+			expect(selector.io_wait(Fiber.current, input, IO::READABLE)).to be == IO::READABLE
+			input.close
+			
+			_, result = Process.wait2(pid)
+		end
+		
+		fiber.transfer
+		
+		# Wait until the result is collected:
+		until result
+			selector.select(1)
+		end
+		
+		expect(result.success?).to be == true
+	end
 end
 
 IO::Event::Selector.constants.each do |name|

--- a/test/io/event/selector/process_io.rb
+++ b/test/io/event/selector/process_io.rb
@@ -38,7 +38,7 @@ ProcessIO = Sus::Shared("process io") do
 		
 		expect(result.success?).to be == true
 	end
-
+	
 	it "can wait for a process which has terminated already" do
 		result = nil
 		


### PR DESCRIPTION
This PR adds an implementation of process_wait using `io_uring_prep_waitid` when available. Since we also need to directly instantiate a `Process::Status` object, we also check for the existence of `rb_process_status_new` (see https://github.com/ruby/ruby/pull/15213).

Note: the use of `pidfd_open` (and then polling on the fd) means that doing `Process.wait(-1)` or `Process.wait(0)` will fail.

## Types of Changes

- Performance improvement.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).