### PR TITLE
Drop compatibility wrapper methods.

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -670,19 +670,6 @@ VALUE IO_Event_Selector_EPoll_io_read(VALUE self, VALUE fiber, VALUE io, VALUE b
 	return rb_ensure(io_read_loop, (VALUE)&io_read_arguments, io_read_ensure, (VALUE)&io_read_arguments);
 }
 
-VALUE IO_Event_Selector_EPoll_io_read_compatible(int argc, VALUE *argv, VALUE self)
-{
-	rb_check_arity(argc, 4, 5);
-	
-	VALUE _offset = SIZET2NUM(0);
-	
-	if (argc == 5) {
-		_offset = argv[4];
-	}
-	
-	return IO_Event_Selector_EPoll_io_read(self, argv[0], argv[1], argv[2], argv[3], _offset);
-}
-
 struct io_write_arguments {
 	VALUE self;
 	VALUE fiber;
@@ -766,19 +753,6 @@ VALUE IO_Event_Selector_EPoll_io_write(VALUE self, VALUE fiber, VALUE io, VALUE 
 	RB_OBJ_WRITTEN(self, Qundef, fiber);
 	
 	return rb_ensure(io_write_loop, (VALUE)&io_write_arguments, io_write_ensure, (VALUE)&io_write_arguments);
-}
-
-VALUE IO_Event_Selector_EPoll_io_write_compatible(int argc, VALUE *argv, VALUE self)
-{
-	rb_check_arity(argc, 4, 5);
-	
-	VALUE _offset = SIZET2NUM(0);
-	
-	if (argc == 5) {
-		_offset = argv[4];
-	}
-	
-	return IO_Event_Selector_EPoll_io_write(self, argv[0], argv[1], argv[2], argv[3], _offset);
 }
 
 #endif
@@ -1081,13 +1055,9 @@ void Init_IO_Event_Selector_EPoll(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_EPoll, "io_wait", IO_Event_Selector_EPoll_io_wait, 3);
 	
 #ifdef HAVE_RUBY_IO_BUFFER_H
-	rb_define_method(IO_Event_Selector_EPoll, "io_read", IO_Event_Selector_EPoll_io_read_compatible, -1);
-	rb_define_method(IO_Event_Selector_EPoll, "io_write", IO_Event_Selector_EPoll_io_write_compatible, -1);
+	rb_define_method(IO_Event_Selector_EPoll, "io_read", IO_Event_Selector_EPoll_io_read, 5);
+	rb_define_method(IO_Event_Selector_EPoll, "io_write", IO_Event_Selector_EPoll_io_write, 5);
 #endif
-	
-	// Once compatibility isn't a concern, we can do this:
-	// rb_define_method(IO_Event_Selector_EPoll, "io_read", IO_Event_Selector_EPoll_io_read, 5);
-	// rb_define_method(IO_Event_Selector_EPoll, "io_write", IO_Event_Selector_EPoll_io_write, 5);
 	
 	rb_define_method(IO_Event_Selector_EPoll, "process_wait", IO_Event_Selector_EPoll_process_wait, 3);
 }

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -668,19 +668,6 @@ VALUE IO_Event_Selector_KQueue_io_read(VALUE self, VALUE fiber, VALUE io, VALUE 
 	return rb_ensure(io_read_loop, (VALUE)&io_read_arguments, io_read_ensure, (VALUE)&io_read_arguments);
 }
 
-static VALUE IO_Event_Selector_KQueue_io_read_compatible(int argc, VALUE *argv, VALUE self)
-{
-	rb_check_arity(argc, 4, 5);
-	
-	VALUE _offset = SIZET2NUM(0);
-	
-	if (argc == 5) {
-		_offset = argv[4];
-	}
-	
-	return IO_Event_Selector_KQueue_io_read(self, argv[0], argv[1], argv[2], argv[3], _offset);
-}
-
 struct io_write_arguments {
 	VALUE self;
 	VALUE fiber;
@@ -774,19 +761,6 @@ VALUE IO_Event_Selector_KQueue_io_write(VALUE self, VALUE fiber, VALUE io, VALUE
 	RB_OBJ_WRITTEN(self, Qundef, fiber);
 	
 	return rb_ensure(io_write_loop, (VALUE)&io_write_arguments, io_write_ensure, (VALUE)&io_write_arguments);
-}
-
-static VALUE IO_Event_Selector_KQueue_io_write_compatible(int argc, VALUE *argv, VALUE self)
-{
-	rb_check_arity(argc, 4, 5);
-	
-	VALUE _offset = SIZET2NUM(0);
-	
-	if (argc == 5) {
-		_offset = argv[4];
-	}
-	
-	return IO_Event_Selector_KQueue_io_write(self, argv[0], argv[1], argv[2], argv[3], _offset);
 }
 
 #endif
@@ -1092,8 +1066,8 @@ void Init_IO_Event_Selector_KQueue(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_KQueue, "io_wait", IO_Event_Selector_KQueue_io_wait, 3);
 	
 #ifdef HAVE_RUBY_IO_BUFFER_H
-	rb_define_method(IO_Event_Selector_KQueue, "io_read", IO_Event_Selector_KQueue_io_read_compatible, -1);
-	rb_define_method(IO_Event_Selector_KQueue, "io_write", IO_Event_Selector_KQueue_io_write_compatible, -1);
+	rb_define_method(IO_Event_Selector_KQueue, "io_read", IO_Event_Selector_KQueue_io_read, 5);
+	rb_define_method(IO_Event_Selector_KQueue, "io_write", IO_Event_Selector_KQueue_io_write, 5);
 #endif
 	
 	rb_define_method(IO_Event_Selector_KQueue, "process_wait", IO_Event_Selector_KQueue_process_wait, 3);

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -747,19 +747,6 @@ VALUE IO_Event_Selector_URing_io_read(VALUE self, VALUE fiber, VALUE io, VALUE b
 	return rb_fiber_scheduler_io_result(total, 0);
 }
 
-static VALUE IO_Event_Selector_URing_io_read_compatible(int argc, VALUE *argv, VALUE self)
-{
-	rb_check_arity(argc, 4, 5);
-	
-	VALUE _offset = SIZET2NUM(0);
-	
-	if (argc == 5) {
-		_offset = argv[4];
-	}
-	
-	return IO_Event_Selector_URing_io_read(self, argv[0], argv[1], argv[2], argv[3], _offset);
-}
-
 VALUE IO_Event_Selector_URing_io_pread(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _from, VALUE _length, VALUE _offset) {
 	struct IO_Event_Selector_URing *selector = NULL;
 	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, selector);
@@ -913,19 +900,6 @@ VALUE IO_Event_Selector_URing_io_write(VALUE self, VALUE fiber, VALUE io, VALUE 
 	}
 	
 	return rb_fiber_scheduler_io_result(total, 0);
-}
-
-static VALUE IO_Event_Selector_URing_io_write_compatible(int argc, VALUE *argv, VALUE self)
-{
-	rb_check_arity(argc, 4, 5);
-	
-	VALUE _offset = SIZET2NUM(0);
-	
-	if (argc == 5) {
-		_offset = argv[4];
-	}
-	
-	return IO_Event_Selector_URing_io_write(self, argv[0], argv[1], argv[2], argv[3], _offset);
 }
 
 VALUE IO_Event_Selector_URing_io_pwrite(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _from, VALUE _length, VALUE _offset) {
@@ -1249,8 +1223,8 @@ void Init_IO_Event_Selector_URing(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_URing, "io_wait", IO_Event_Selector_URing_io_wait, 3);
 	
 #ifdef HAVE_RUBY_IO_BUFFER_H
-	rb_define_method(IO_Event_Selector_URing, "io_read", IO_Event_Selector_URing_io_read_compatible, -1);
-	rb_define_method(IO_Event_Selector_URing, "io_write", IO_Event_Selector_URing_io_write_compatible, -1);
+	rb_define_method(IO_Event_Selector_URing, "io_read", IO_Event_Selector_URing_io_read, 5);
+	rb_define_method(IO_Event_Selector_URing, "io_write", IO_Event_Selector_URing_io_write, 5);
 	rb_define_method(IO_Event_Selector_URing, "io_pread", IO_Event_Selector_URing_io_pread, 6);
 	rb_define_method(IO_Event_Selector_URing, "io_pwrite", IO_Event_Selector_URing_io_pwrite, 6);
 #endif

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -478,7 +478,7 @@ Selector = Sus::Shared("a selector") do
 			
 			fiber = Fiber.new do
 				events << :io_read
-				offset = selector.io_read(Fiber.current, local, buffer, message.bytesize)
+				offset = selector.io_read(Fiber.current, local, buffer, message.bytesize, 0)
 				expect(buffer.get_string(0, offset)).to be == message
 			end
 			
@@ -499,7 +499,7 @@ Selector = Sus::Shared("a selector") do
 			
 			fiber = Fiber.new do
 				events << :io_read
-				offset = selector.io_read(Fiber.current, local, buffer, message.bytesize)
+				offset = selector.io_read(Fiber.current, local, buffer, message.bytesize, 0)
 				expect(buffer.get_string(0, offset)).to be == message
 			end
 			
@@ -521,7 +521,7 @@ Selector = Sus::Shared("a selector") do
 			return unless selector.respond_to?(:io_read)
 			
 			fiber = Fiber.new do
-				offset = selector.io_read(Fiber.current, local, buffer, message.bytesize)
+				offset = selector.io_read(Fiber.current, local, buffer, message.bytesize, 0)
 				expect(buffer.get_string(0, offset)).to be == message
 				sleep(0.001)
 			end
@@ -559,7 +559,7 @@ Selector = Sus::Shared("a selector") do
 			fiber = Fiber.new do
 				events << :io_write
 				buffer = IO::Buffer.for(message.dup)
-				result = selector.io_write(Fiber.current, local, buffer, buffer.size)
+				result = selector.io_write(Fiber.current, local, buffer, buffer.size, 0)
 				expect(result).to be == message.bytesize
 				local.close
 			end

--- a/test/io/event/selector/buffered_io.rb
+++ b/test/io/event/selector/buffered_io.rb
@@ -21,12 +21,12 @@ BufferedIO = Sus::Shared("buffered io") do
 			
 			writer = Fiber.new do
 				buffer = IO::Buffer.new(128)
-				expect(selector.io_write(Fiber.current, output, buffer, 128)).to be == 128
+				expect(selector.io_write(Fiber.current, output, buffer, 128, 0)).to be == 128
 			end
 			
 			reader = Fiber.new do
 				buffer = IO::Buffer.new(64)
-				expect(selector.io_read(Fiber.current, input, buffer, 1)).to be == 64
+				expect(selector.io_read(Fiber.current, input, buffer, 1, 0)).to be == 64
 			end
 			
 			reader.transfer
@@ -39,7 +39,7 @@ BufferedIO = Sus::Shared("buffered io") do
 			skip_if_ruby_platform(/mswin|mingw|cygwin/)
 			
 			buffer = IO::Buffer.new(1).slice(0, 0)
-			expect(selector.io_write(Fiber.current, output, buffer, 0)).to be == 0
+			expect(selector.io_write(Fiber.current, output, buffer, 0, 0)).to be == 0
 		end
 		
 		it "can read and write at the specified offset" do
@@ -70,7 +70,7 @@ BufferedIO = Sus::Shared("buffered io") do
 			
 			writer = Fiber.new do
 				buffer = IO::Buffer.new(64)
-				result = selector.io_write(Fiber.current, input, buffer, 64)
+				result = selector.io_write(Fiber.current, input, buffer, 64, 0)
 				expect(result).to be < 0
 			end
 			
@@ -88,7 +88,7 @@ BufferedIO = Sus::Shared("buffered io") do
 			output.close
 			
 			reader = Fiber.new do
-				result = selector.io_read(Fiber.current, input, buffer, 0)
+				result = selector.io_read(Fiber.current, input, buffer, 0, 0)
 			end
 			
 			reader.transfer
@@ -109,7 +109,7 @@ BufferedIO = Sus::Shared("buffered io") do
 			result = nil
 			
 			reader = Fiber.new do
-				result = selector.io_read(Fiber.current, input, buffer, 0)
+				result = selector.io_read(Fiber.current, input, buffer, 0, 0)
 			end
 			
 			reader.transfer

--- a/test/io/event/selector/cancellable.rb
+++ b/test/io/event/selector/cancellable.rb
@@ -25,7 +25,7 @@ Cancellable = Sus::Shared("cancellable") do
 				buffer = IO::Buffer.new(64)
 				
 				10.times do
-					expect{selector.io_read(Fiber.current, input, buffer, 1)}.to raise_exception(Interrupt)
+					expect{selector.io_read(Fiber.current, input, buffer, 1, 0)}.to raise_exception(Interrupt)
 				end
 			end
 			
@@ -44,7 +44,7 @@ Cancellable = Sus::Shared("cancellable") do
 				
 				10.times do
 					expect{selector.io_wait(Fiber.current, input, IO::READABLE)}.to raise_exception(Interrupt)
-					selector.io_read(Fiber.current, input, buffer, 1)
+					selector.io_read(Fiber.current, input, buffer, 1, 0)
 				end
 			end
 			

--- a/test/io/event/selector/file_io.rb
+++ b/test/io/event/selector/file_io.rb
@@ -20,7 +20,7 @@ FileIO = Sus::Shared("file io") do
 			writer = Fiber.new do
 				buffer = IO::Buffer.new(128)
 				file.seek(0)
-				write_result = selector.io_write(Fiber.current, file, buffer, 128)
+				write_result = selector.io_write(Fiber.current, file, buffer, 128, 0)
 			end
 			
 			reader = Fiber.new do
@@ -28,7 +28,7 @@ FileIO = Sus::Shared("file io") do
 				file.seek(0)
 				
 				# The read will return 0 if the data is not written yet:
-				read_result = selector.io_read(Fiber.current, file, buffer, 0)
+				read_result = selector.io_read(Fiber.current, file, buffer, 0, 0)
 			end
 			
 			writer.transfer

--- a/test/io/event/selector/write_deadlock.rb
+++ b/test/io/event/selector/write_deadlock.rb
@@ -37,7 +37,7 @@ WriteDeadlock = Sus::Shared("write deadlock") do
 			# Writer fiber that should hit EAGAIN and wait for WRITABLE
 			writer = Fiber.new do
 				buffer = IO::Buffer.for("test" * 64)  # 256 bytes
-				@selector.io_write(Fiber.current, local, buffer, buffer.size)
+				@selector.io_write(Fiber.current, local, buffer, buffer.size, 0)
 				write_completed = true
 			end
 			


### PR DESCRIPTION
The compatibility interfaces allow an optional offset. I wonder if we can drop them?

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Breaking change.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
