### PR TITLE
Use eventfd for wakeup and enable io_uring performance flags

### DIFF
--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -11,6 +11,8 @@
 #include <stdint.h>
 #include <time.h>
 
+#include "../interrupt.h"
+
 #include "pidfd.c"
 
 #include <linux/version.h>
@@ -33,8 +35,20 @@ struct IO_Event_Selector_URing
 	
 	// Flag indicating whether the selector is currently blocked in a system call.
 	// Set to 1 when blocked in io_uring_wait_cqe_timeout() without GVL, 0 otherwise.
-	// Used by wakeup() to determine if an interrupt signal is needed.
 	int blocked;
+	
+	// Interrupt used to wake the selector from another thread without touching the ring's SQ.
+	// This allows IORING_SETUP_SINGLE_ISSUER: only the owner thread ever submits SQEs.
+	// Uses eventfd on Linux, pipe fallback elsewhere.
+	struct IO_Event_Interrupt interrupt;
+	
+	// Whether an async read on interrupt is currently pending in the ring.
+	// The read is re-submitted before each blocking wait when not registered.
+	int wakeup_registered;
+	
+	// Buffer for the pending async read on the interrupt descriptor.
+	// Must remain valid for the lifetime of the in-flight SQE.
+	uint64_t wakeup_value;
 	
 	struct timespec idle_duration;
 	
@@ -101,6 +115,12 @@ void IO_Event_Selector_URing_Type_compact(void *_selector)
 static
 void close_internal(struct IO_Event_Selector_URing *selector)
 {
+	if (selector->interrupt.descriptor >= 0) {
+		IO_Event_Interrupt_close(&selector->interrupt);
+		selector->interrupt.descriptor = -1;
+		selector->wakeup_registered = 0;
+	}
+	
 	if (selector->ring.ring_fd >= 0) {
 		io_uring_queue_exit(&selector->ring);
 		selector->ring.ring_fd = -1;
@@ -220,6 +240,8 @@ VALUE IO_Event_Selector_URing_allocate(VALUE self) {
 	
 	selector->pending = 0;
 	selector->blocked = 0;
+	selector->interrupt.descriptor = -1;
+	selector->wakeup_registered = 0;
 	
 	IO_Event_List_initialize(&selector->free_list);
 	
@@ -240,13 +262,38 @@ VALUE IO_Event_Selector_URing_initialize(VALUE self, VALUE loop) {
 	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, selector);
 	
 	IO_Event_Selector_initialize(&selector->backend, self, loop);
-	int result = io_uring_queue_init(URING_ENTRIES, &selector->ring, 0);
+	
+	unsigned int flags = 0;
+	// IORING_SETUP_SINGLE_ISSUER (kernel 6.0+): only the owner thread submits SQEs.
+	// Safe here because wakeup() uses eventfd (no ring access from other threads).
+#ifdef IORING_SETUP_SINGLE_ISSUER
+	flags |= IORING_SETUP_SINGLE_ISSUER;
+#endif
+	// IORING_SETUP_DEFER_TASKRUN (kernel 6.1+, requires SINGLE_ISSUER): defer io_uring
+	// task work to the application thread rather than a kernel thread, reducing
+	// cross-CPU signaling overhead. io_uring_get_events() is called before the
+	// non-blocking CQ check in select() to flush deferred work into the CQ.
+#ifdef IORING_SETUP_DEFER_TASKRUN
+	flags |= IORING_SETUP_DEFER_TASKRUN;
+#endif
+	
+	int result = io_uring_queue_init(URING_ENTRIES, &selector->ring, flags);
 	
 	if (result < 0) {
 		rb_syserr_fail(-result, "IO_Event_Selector_URing_initialize:io_uring_queue_init");
 	}
 	
 	rb_update_max_fd(selector->ring.ring_fd);
+	
+	// Interrupt for cross-thread wakeup: another thread calls signal(); the owner
+	// thread submits an async read before each blocking wait so the ring wakes up
+	// without the waking thread ever touching the SQ.
+	IO_Event_Interrupt_open(&selector->interrupt);
+	if (selector->interrupt.descriptor < 0) {
+		io_uring_queue_exit(&selector->ring);
+		selector->ring.ring_fd = -1;
+		rb_sys_fail("IO_Event_Selector_URing_initialize:IO_Event_Interrupt_open");
+	}
 	
 	return self;
 }
@@ -1072,11 +1119,25 @@ void * select_internal(void *_arguments) {
 
 static
 int select_internal_without_gvl(struct select_arguments *arguments) {
-	io_uring_submit_flush(arguments->selector);
+	struct IO_Event_Selector_URing *selector = arguments->selector;
 	
-	arguments->selector->blocked = 1;
+	// Submit an async read on the wakeup eventfd before releasing the GVL.
+	// When wakeup() writes to the fd the read completes, consuming the counter
+	// atomically — no separate poll + drain step required.
+	// The address of the interrupt struct serves as a unique sentinel in user_data.
+	if (!selector->wakeup_registered) {
+		struct io_uring_sqe *sqe = io_get_sqe(selector);
+		io_uring_prep_read(sqe, IO_Event_Interrupt_descriptor(&selector->interrupt), &selector->wakeup_value, sizeof(selector->wakeup_value), 0);
+		io_uring_sqe_set_data(sqe, &selector->interrupt);
+		selector->wakeup_registered = 1;
+		selector->pending += 1;
+	}
+	
+	io_uring_submit_flush(selector);
+	
+	selector->blocked = 1;
 	rb_thread_call_without_gvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
-	arguments->selector->blocked = 0;
+	selector->blocked = 0;
 	
 	if (arguments->result == -ETIME) {
 		arguments->result = 0;
@@ -1111,6 +1172,14 @@ unsigned select_process_completions(struct IO_Event_Selector_URing *selector) {
 		
 		// If the operation was cancelled, or the operation has no user data:
 		if (cqe->user_data == 0 || cqe->user_data == LIBURING_UDATA_TIMEOUT) {
+			io_uring_cq_advance(ring, 1);
+			continue;
+		}
+		
+		// Interrupt read completion — the read already consumed the counter.
+		// Clear the flag so the next blocking wait re-submits the read.
+		if (io_uring_cqe_get_data(cqe) == &selector->interrupt) {
+			selector->wakeup_registered = 0;
 			io_uring_cq_advance(ring, 1);
 			continue;
 		}
@@ -1157,6 +1226,16 @@ VALUE IO_Event_Selector_URing_select(VALUE self, VALUE duration) {
 	// Flush any pending events:
 	io_uring_submit_flush(selector);
 	
+#ifdef IORING_SETUP_DEFER_TASKRUN
+	// With DEFER_TASKRUN the kernel holds completions as "deferred task work"
+	// rather than placing them directly into the CQ. io_uring_get_events() calls
+	// io_uring_enter with IORING_ENTER_GETEVENTS (without blocking) to flush that
+	// work into the CQ so the non-blocking select_process_completions below sees them.
+	if (selector->ring.flags & IORING_SETUP_DEFER_TASKRUN) {
+		io_uring_get_events(&selector->ring);
+	}
+#endif
+	
 	int ready = IO_Event_Selector_ready_flush(&selector->backend);
 	
 	int result = select_process_completions(selector);
@@ -1200,25 +1279,10 @@ VALUE IO_Event_Selector_URing_wakeup(VALUE self) {
 	struct IO_Event_Selector_URing *selector = NULL;
 	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, selector);
 	
-	// If we are blocking, we can schedule a nop event to wake up the selector:
+	// Wake the selector by signalling the interrupt. This is safe from any thread
+	// and never touches the ring's SQ, which is required for IORING_SETUP_SINGLE_ISSUER.
 	if (selector->blocked) {
-		struct io_uring_sqe *sqe = NULL;
-		
-		while (true) {
-			sqe = io_uring_get_sqe(&selector->ring);
-			if (sqe) break;
-			
-			rb_thread_schedule();
-			
-			// It's possible we became unblocked already, so we can assume the selector has already cycled at least once:
-			if (!selector->blocked) return Qfalse;
-		}
-		
-		io_uring_prep_nop(sqe);
-		// If you don't set this line, the SQE will eventually be recycled and have valid user selector which can cause odd behaviour:
-		io_uring_sqe_set_data(sqe, NULL);
-		io_uring_submit(&selector->ring);
-		
+		IO_Event_Interrupt_signal(&selector->interrupt);
 		return Qtrue;
 	}
 	
@@ -1229,7 +1293,15 @@ VALUE IO_Event_Selector_URing_wakeup(VALUE self) {
 
 static int IO_Event_Selector_URing_supported_p(void) {
 	struct io_uring ring;
-	int result = io_uring_queue_init(32, &ring, 0);
+	
+	unsigned int flags = 0;
+#ifdef IORING_SETUP_SINGLE_ISSUER
+	flags |= IORING_SETUP_SINGLE_ISSUER;
+#endif
+#ifdef IORING_SETUP_DEFER_TASKRUN
+	flags |= IORING_SETUP_DEFER_TASKRUN;
+#endif
+	int result = io_uring_queue_init(32, &ring, flags);
 	
 	if (result < 0) {
 		rb_warn("io_uring_queue_init() was available at compile time but failed at run time: %s\n", strerror(-result));

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -271,10 +271,16 @@ VALUE IO_Event_Selector_URing_initialize(VALUE self, VALUE loop) {
 #endif
 	// IORING_SETUP_DEFER_TASKRUN (kernel 6.1+, requires SINGLE_ISSUER): defer io_uring
 	// task work to the application thread rather than a kernel thread, reducing
-	// cross-CPU signaling overhead. io_uring_get_events() is called before the
-	// non-blocking CQ check in select() to flush deferred work into the CQ.
+	// cross-CPU signaling overhead.
 #ifdef IORING_SETUP_DEFER_TASKRUN
 	flags |= IORING_SETUP_DEFER_TASKRUN;
+#endif
+	// IORING_SETUP_TASKRUN_FLAG (kernel 5.19+, always available alongside
+	// DEFER_TASKRUN): the kernel surfaces IORING_SQ_TASKRUN in sq.flags whenever
+	// task work is pending, so select() can skip the io_uring_get_events()
+	// syscall when there is nothing deferred to flush.
+#ifdef IORING_SETUP_TASKRUN_FLAG
+	flags |= IORING_SETUP_TASKRUN_FLAG;
 #endif
 	
 	int result = io_uring_queue_init(URING_ENTRIES, &selector->ring, flags);
@@ -1228,11 +1234,20 @@ VALUE IO_Event_Selector_URing_select(VALUE self, VALUE duration) {
 	
 #ifdef IORING_SETUP_DEFER_TASKRUN
 	// With DEFER_TASKRUN the kernel holds completions as "deferred task work"
-	// rather than placing them directly into the CQ. io_uring_get_events() calls
-	// io_uring_enter with IORING_ENTER_GETEVENTS (without blocking) to flush that
-	// work into the CQ so the non-blocking select_process_completions below sees them.
+	// rather than placing them directly into the CQ.  We need to flush that work
+	// into the CQ so the non-blocking select_process_completions below can see
+	// it.  With TASKRUN_FLAG enabled the kernel sets IORING_SQ_TASKRUN in
+	// sq.flags whenever task work is pending; a relaxed atomic load is enough
+	// to check, and we only pay for an io_uring_enter syscall (via
+	// io_uring_get_events) when there is actually deferred work to flush.
 	if (selector->ring.flags & IORING_SETUP_DEFER_TASKRUN) {
-		io_uring_get_events(&selector->ring);
+#ifdef IORING_SETUP_TASKRUN_FLAG
+		unsigned sq_flags = __atomic_load_n(selector->ring.sq.kflags, __ATOMIC_RELAXED);
+		if (sq_flags & IORING_SQ_TASKRUN)
+#endif
+		{
+			io_uring_get_events(&selector->ring);
+		}
 	}
 #endif
 	
@@ -1300,6 +1315,9 @@ static int IO_Event_Selector_URing_supported_p(void) {
 #endif
 #ifdef IORING_SETUP_DEFER_TASKRUN
 	flags |= IORING_SETUP_DEFER_TASKRUN;
+#endif
+#ifdef IORING_SETUP_TASKRUN_FLAG
+	flags |= IORING_SETUP_TASKRUN_FLAG;
 #endif
 	int result = io_uring_queue_init(32, &ring, flags);
 	


### PR DESCRIPTION
The current cross-thread `wakeup()` submits a NOP SQE directly into the ring's submission queue from the waking thread. That cross-thread SQ access prevents enabling several kernel performance flags that require single-issuer semantics, and forces a sub-optimal completion path.

This PR rewires `wakeup()` to use an `eventfd` (Linux) / pipe (other Unix) via `IO_Event_Interrupt`, so the waking thread never touches the ring. With that constraint satisfied, three kernel flags become safe to set, each gated by `#ifdef` and degrading gracefully on older kernels / liburing.

## Changes

### `eventfd`-based wakeup

1. Before each blocking `io_uring_wait_cqe_timeout`, the **owner thread** submits a one-shot async `read` on the interrupt descriptor (tagged with `&selector->interrupt`).
2. `wakeup()` — called from any thread — calls `IO_Event_Interrupt_signal()`, a plain `write()` that bumps the eventfd counter. **No ring access from the waking thread.**
3. The kernel completes the read, `wait_cqe_timeout` returns, the read atomically consumed the counter, so no separate drain step is needed.

### `IORING_SETUP_SINGLE_ISSUER` (kernel 6.0+)

Tells the kernel only the owner thread will ever submit SQEs, letting it skip internal SQ locking on every submit call.

### `IORING_SETUP_DEFER_TASKRUN` (kernel 6.1+, requires `SINGLE_ISSUER`)

Defers io_uring task work to the application thread instead of running it via `TWA_SIGNAL` at arbitrary userspace re-entries. Eliminates the cross-CPU IPI and the unpredictable preemption window, and lets all completions drain in a single kernel pass at the next `GETEVENTS` boundary.

Because the CQ stays empty until something explicitly enters io_uring with `GETEVENTS`, `select()` calls `io_uring_get_events()` at the top — before the non-blocking `select_process_completions()` peek — so deferred completions are visible without forcing a blocking wait.

### `IORING_SETUP_TASKRUN_FLAG` (kernel 5.19+) — follow-up

The unconditional `io_uring_get_events()` is a real syscall every `select()` iteration. `TASKRUN_FLAG` asks the kernel to set `IORING_SQ_TASKRUN` in `sq.flags` whenever task work is pending; we read the bit via a relaxed atomic load on the mmap'd flag word and only enter the kernel when there is something to flush. Suggested by @tavianator in review.

### Benchmark CI

`benchmark.yaml` was missing `liburing-dev`, so benchmarks silently fell back to EPoll. Added the apt step so the URing benchmark job actually exercises URing.

## Benchmark

hana.oriontransfer.co.nz, Linux 6.19.11, Ruby 3.4.9, dedicated machine.

**Wakeup latency** (`benchmark/selector_wakeup.rb`):

| Backend | `main` | This PR |
|---|---|---|
| URing cross-thread roundtrip | 9.32 µs | 10.21 µs |
| URing idle wakeup | 1.54 µs | 1.53 µs |

The ~1 µs roundtrip gap vs the NOP wakeup is the irreducible cost of going through `eventfd` + the kernel completing a pending async read; `DEFER_TASKRUN` closes most of what would otherwise be a ~2.6 µs gap.

**TASKRUN_FLAG isolation** — tight `select(0)` loop with nothing pending (200k iterations, n=5):

| | ns/call | M calls/s |
|---|---|---|
| `DEFER_TASKRUN` only | ~570 ns | 1.75 |
| + `TASKRUN_FLAG` | ~58 ns | 17 |

`strace -e io_uring_enter` over 10 such calls: 10 syscalls → **0**.

**HTTP** (`benchmark/server/event.rb`, 8 connections, 2s wrk runs, 7 reps averaged):

| | `main` | This PR |
|---|---|---|
| Average req/s | 14,375 | 14,594 |
| Δ | | **+1.5%** |

The HTTP improvement comes mostly from `DEFER_TASKRUN` (task work no longer interrupts the loop at arbitrary points); the wakeup path itself is slightly slower, but it's amortised across every event.

## Testing

The existing `wakeup` correctness tests in `test/io/event/selector.rb` cover the cross-thread wakeup path. CI runs them on Ubuntu with `liburing-dev` installed. The benchmark workflow now also runs against URing so we get a continuous signal.