### PR TITLE
io_uring improvements

### DIFF
--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -8,6 +8,7 @@
 
 #include <liburing.h>
 #include <poll.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
 
@@ -406,30 +407,33 @@ void IO_Event_Selector_URing_dump_completion_queue(struct IO_Event_Selector_URin
 	}
 }
 
-// Flush the submission queue if pending operations are present.
+// Flush the submission queue, optionally yielding if unsuccessful.
 static
-int io_uring_submit_flush(struct IO_Event_Selector_URing *selector) {
-	if (selector->pending) {
-		if (DEBUG) fprintf(stderr, "io_uring_submit_flush(pending=%ld)\n", selector->pending);
-		
-		// Try to submit:
+int io_uring_submit_all(struct IO_Event_Selector_URing *selector, bool yield) {
+	while (selector->pending > 0) {
 		int result = io_uring_submit(&selector->ring);
 		
 		if (result >= 0) {
-			// If it was submitted, reset pending count:
-			selector->pending = 0;
-		} else if (result != -EBUSY && result != -EAGAIN) {
-			rb_syserr_fail(-result, "io_uring_submit_flush:io_uring_submit");
+			// io_uring_submit() returns the number of submitted SQEs
+			selector->pending -= result;
+		} else if (result == -EBUSY || result == -EAGAIN) {
+			if (yield) IO_Event_Selector_yield(&selector->backend);
+		} else {
+			rb_syserr_fail(-result, "io_uring_submit_all:io_uring_submit");
+			return result;
 		}
-		
-		return result;
 	}
-	
-	if (DEBUG) {
-		IO_Event_Selector_URing_dump_completion_queue(selector);
-	}
-	
+
+	if (DEBUG) IO_Event_Selector_URing_dump_completion_queue(selector);
 	return 0;
+}
+
+// Flush the submission queue if pending operations are present.
+static
+int io_uring_submit_flush(struct IO_Event_Selector_URing *selector) {
+	if (DEBUG) fprintf(stderr, "io_uring_submit_now(pending=%ld)\n", selector->pending);
+
+	return io_uring_submit_all(selector, false);
 }
 
 // Immediately flush the submission queue, yielding to the event loop if it was not successful.
@@ -437,28 +441,12 @@ static
 int io_uring_submit_now(struct IO_Event_Selector_URing *selector) {
 	if (DEBUG) fprintf(stderr, "io_uring_submit_now(pending=%ld)\n", selector->pending);
 	
-	while (true) {
-		int result = io_uring_submit(&selector->ring);
-		
-		if (result >= 0) {
-			selector->pending = 0;
-			if (DEBUG) IO_Event_Selector_URing_dump_completion_queue(selector);
-			return result;
-		}
-		
-		if (result == -EBUSY || result == -EAGAIN) {
-			IO_Event_Selector_yield(&selector->backend);
-		} else {
-			rb_syserr_fail(-result, "io_uring_submit_now:io_uring_submit");
-		}
-	}
+	return io_uring_submit_all(selector, true);
 }
 
 // Submit a pending operation. This does not submit the operation immediately, but instead defers it to the next call to `io_uring_submit_flush` or `io_uring_submit_now`. This is useful for operations that are not urgent, but should be used with care as it can lead to a deadlock if the submission queue is not flushed.
 static
 void io_uring_submit_pending(struct IO_Event_Selector_URing *selector) {
-	selector->pending += 1;
-	
 	if (DEBUG) fprintf(stderr, "io_uring_submit_pending(ring=%p, pending=%ld)\n", &selector->ring, selector->pending);
 }
 
@@ -471,7 +459,8 @@ struct io_uring_sqe * io_get_sqe(struct IO_Event_Selector_URing *selector) {
 		
 		sqe = io_uring_get_sqe(&selector->ring);
 	}
-	
+
+	selector->pending += 1;
 	return sqe;
 }
 
@@ -1136,7 +1125,6 @@ int select_internal_without_gvl(struct select_arguments *arguments) {
 		io_uring_prep_read(sqe, IO_Event_Interrupt_descriptor(&selector->interrupt), &selector->wakeup_value, sizeof(selector->wakeup_value), 0);
 		io_uring_sqe_set_data(sqe, &selector->interrupt);
 		selector->wakeup_registered = 1;
-		selector->pending += 1;
 	}
 	
 	io_uring_submit_flush(selector);

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -283,8 +283,22 @@ VALUE IO_Event_Selector_URing_initialize(VALUE self, VALUE loop) {
 #ifdef IORING_SETUP_TASKRUN_FLAG
 	flags |= IORING_SETUP_TASKRUN_FLAG;
 #endif
+	// IORING_SETUP_SUBMIT_ALL (kernel 5.18+): keep processing the rest of the SQE
+	// batch even when one fails, reducing the frequency of short submits.
+#ifdef IORING_SETUP_SUBMIT_ALL
+	flags |= IORING_SETUP_SUBMIT_ALL;
+#endif
 	
 	int result = io_uring_queue_init(URING_ENTRIES, &selector->ring, flags);
+	
+#ifdef IORING_SETUP_SUBMIT_ALL
+	if (result == -EINVAL) {
+		// IORING_SETUP_SUBMIT_ALL was added in Linux 5.18; retry without it.
+		if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_initialize: no IORING_SETUP_SUBMIT_ALL\n");
+		flags &= ~IORING_SETUP_SUBMIT_ALL;
+		result = io_uring_queue_init(URING_ENTRIES, &selector->ring, flags);
+	}
+#endif
 	
 	if (result < 0) {
 		rb_syserr_fail(-result, "IO_Event_Selector_URing_initialize:io_uring_queue_init");
@@ -1307,7 +1321,17 @@ static int IO_Event_Selector_URing_supported_p(void) {
 #ifdef IORING_SETUP_TASKRUN_FLAG
 	flags |= IORING_SETUP_TASKRUN_FLAG;
 #endif
+#ifdef IORING_SETUP_SUBMIT_ALL
+	flags |= IORING_SETUP_SUBMIT_ALL;
+#endif
 	int result = io_uring_queue_init(32, &ring, flags);
+	
+#ifdef IORING_SETUP_SUBMIT_ALL
+	if (result == -EINVAL) {
+		flags &= ~IORING_SETUP_SUBMIT_ALL;
+		result = io_uring_queue_init(32, &ring, flags);
+	}
+#endif
 	
 	if (result < 0) {
 		rb_warn("io_uring_queue_init() was available at compile time but failed at run time: %s\n", strerror(-result));

--- a/releases.md
+++ b/releases.md
@@ -7,6 +7,7 @@
   - Improve `WorkerPool` GC compaction support and add proper write barriers, fixing potential use-after-free under compacting GC.
   - Keep blocked scheduler fibers alive during GC by registering them as roots in `TestScheduler#block`, preventing premature collection and the resulting use-after-free crash on resume.
   - Correctly handle short `io_uring_submit()` results in the `URing` selector. `io_uring_submit()` returns the number of SQEs actually accepted by the kernel and can be short (SQE prep errors, `ENOMEM`, transient `EAGAIN`); the old accounting reset `pending = 0` on any success and silently lost track of unsubmitted SQEs.
+  - Enable `IORING_SETUP_SUBMIT_ALL` (kernel 5.18+) on the `URing` selector so the kernel keeps processing the rest of an SQE batch past individual errors, reducing the frequency of short submits in practice.
 
 ## v1.15.1
 

--- a/releases.md
+++ b/releases.md
@@ -6,6 +6,7 @@
   - Add support for the `io_close` fiber-scheduler hook (Ruby 4.0+). The `URing` selector performs the close asynchronously via the ring; the `Debug::Selector` and `TestScheduler` wrappers forward to the underlying selector when supported.
   - Improve `WorkerPool` GC compaction support and add proper write barriers, fixing potential use-after-free under compacting GC.
   - Keep blocked scheduler fibers alive during GC by registering them as roots in `TestScheduler#block`, preventing premature collection and the resulting use-after-free crash on resume.
+  - Correctly handle short `io_uring_submit()` results in the `URing` selector. `io_uring_submit()` returns the number of SQEs actually accepted by the kernel and can be short (SQE prep errors, `ENOMEM`, transient `EAGAIN`); the old accounting reset `pending = 0` on any success and silently lost track of unsubmitted SQEs.
 
 ## v1.15.1
 


### PR DESCRIPTION
Some `io_uring` changes, feel free to take some or all of these.

I tried also adding `IORING_SETUP_DEFER_TASKRUN` but it didn't pass the test suite, I assume because with `SINGLE_ISSUER` we're waiting with `ppoll()` instead of `io_uring_enter()` (and thus some task_work never runs).

- **Handle short io_uring submissions**
- **Try setting up io_uring with IORING_SETUP_SUBMIT_ALL**
- **Use IORING_SETUP_SINGLE_ISSUER if possible**

## Types of Changes

- Performance improvement.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
