### PR TITLE
Benchmark EPoll and URing side-by-side in CI

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -4,36 +4,47 @@ on: [push, pull_request]
 
 jobs:
   test:
+    name: ${{matrix.selector}} on ${{matrix.os}} (${{matrix.ruby}})
     runs-on: ${{matrix.os}}-latest
-    
+
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu
-        
+
         ruby:
           - head
-    
+
+        selector:
+          - EPoll
+          - URing
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
-    
+
+    - name: Install packages (Ubuntu)
+      if: matrix.os == 'ubuntu'
+      run: sudo apt-get install -y liburing-dev
+
     - name: Build extensions
       timeout-minutes: 5
       run: bundle exec bake build
-    
-    - name: Install packages
+
+    - name: Install wrk
       timeout-minutes: 5
       run: |
         git clone https://github.com/ioquatix/wrk
         cd wrk
         make
-    
-    - name: Run benchmarks
-      timeout-minutes: 5
+
+    - name: Run benchmarks (${{matrix.selector}})
+      timeout-minutes: 10
       env:
         WRK: ./wrk/wrk
+        IO_EVENT_SELECTOR: ${{matrix.selector}}
       run: bundle exec bake -b benchmark/server/bake.rb


### PR DESCRIPTION
## Why

The benchmark workflow never installed `liburing-dev`, so every benchmark run silently used epoll. There was no way to compare the two backends without a separate branch.

## What

- Add a `selector` matrix dimension (`EPoll` / `URing`) so both backends run in the same CI pass.
- Set `IO_EVENT_SELECTOR: ${{matrix.selector}}` on the benchmark step — `IO::Event::Selector.default` already reads this env var.
- Install `liburing-dev` so the URing backend is compiled and available.
- Bump `actions/checkout@v2` → `@v4` while here.

## How to read the results

Each job is named `EPoll on ubuntu (head)` / `URing on ubuntu (head)` — compare the `Requests/sec` lines between the two jobs for each server scenario (`event.rb`, `loop.rb`, `thread.rb`, etc.).

This branch is on unmodified `main`, so the numbers serve as a clean baseline before any wakeup / SINGLE_ISSUER changes.

Made with [Cursor](https://cursor.com)