### PR TITLE
Fix io_close crash when called with an Integer fd

### DIFF
--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -1001,7 +1001,9 @@ VALUE IO_Event_Selector_URing_io_close(VALUE self, VALUE io) {
 	struct IO_Event_Selector_URing *selector = NULL;
 	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, selector);
 	
-	int descriptor = IO_Event_Selector_io_descriptor(io);
+	// Ruby's fiber scheduler io_close hook may receive a raw Integer fd
+	// (observed on Ruby head/4.1) rather than an IO object.
+	int descriptor = RB_INTEGER_TYPE_P(io) ? RB_NUM2INT(io) : IO_Event_Selector_io_descriptor(io);
 
 	if (ASYNC_CLOSE) {
 		struct io_uring_sqe *sqe = io_get_sqe(selector);

--- a/test/io/event/selector/io_close.rb
+++ b/test/io/event/selector/io_close.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "io/event"
+require "io/event/selector"
+
+IOClose = Sus::Shared("io_close") do
+	it "can close an IO object" do
+		selector = subject.new(Fiber.current)
+		next unless selector.respond_to?(:io_close)
+		
+		input, output = IO.pipe
+		
+		begin
+			expect(selector.io_close(input)).to be_truthy
+		ensure
+			input.close rescue nil
+			output.close rescue nil
+			selector.close
+		end
+	end
+	
+	# Ruby head/4.1 passes a raw Integer fd to the io_close scheduler hook
+	# instead of an IO object. Verify we handle both forms without raising.
+	it "can close a raw Integer fd" do
+		selector = subject.new(Fiber.current)
+		next unless selector.respond_to?(:io_close)
+		
+		input, output = IO.pipe
+		
+		# Hand ownership of the fd to io_close so Ruby won't double-close it.
+		input.autoclose = false
+		fd = input.fileno
+		
+		begin
+			expect(selector.io_close(fd)).to be_truthy
+		ensure
+			input.close rescue nil
+			output.close rescue nil
+			selector.close
+		end
+	end
+end
+
+IO::Event::Selector.constants.each do |name|
+	klass = IO::Event::Selector.const_get(name)
+	next unless klass.respond_to?(:new)
+	
+	describe(klass, unique: name) do
+		it_behaves_like IOClose
+	end
+end


### PR DESCRIPTION
## Bug

`IO::Event::Selector::URing#io_close` crashed with a `TypeError` when the Ruby fiber scheduler hook passed a raw `Integer` file descriptor instead of an `IO` object:

```
IO::Event::Selector::URing#io_close: expected IO or #fileno, Integer given (TypeError)
```

This was observed on Ruby head/4.1 and caused the `event.rb` and `buffer.rb` benchmark server scenarios to produce zero requests under URing.

## Root cause

`IO_Event_Selector_io_descriptor` maps to `rb_io_descriptor` on modern Ruby (when `HAVE_RB_IO_DESCRIPTOR` is defined), which strictly requires an IO object. The `io_close` scheduler hook was not guarded against receiving a plain integer.

EPoll and KQueue are unaffected because they do not implement `io_close` — the scheduler falls back to Ruby's default close path.

## Fix

Check whether the argument is an `Integer` before calling `rb_io_descriptor`:

```c
int descriptor = RB_INTEGER_TYPE_P(io) ? RB_NUM2INT(io) : IO_Event_Selector_io_descriptor(io);
```

## Tests

Added `test/io/event/selector/io_close.rb` covering:
- Closing via an IO object (existing/documented API)
- Closing via a raw Integer fd (regression test for this bug)

Made with [Cursor](https://cursor.com)