### PR TITLE
Improve GC compaction support and write barriers in WorkerPool

### DIFF
--- a/ext/io/event/worker_pool.c
+++ b/ext/io/event/worker_pool.c
@@ -91,11 +91,20 @@ static void worker_pool_mark(void *ptr)
 	struct IO_Event_WorkerPool *pool = (struct IO_Event_WorkerPool *)ptr;
 	struct IO_Event_WorkerPool_Worker *worker = pool->workers;
 	while (worker) {
-		struct IO_Event_WorkerPool_Worker *next = worker->next;
 		// We need to mark the thread even though its marked through the VM's ractors because we call `join`
 		// on them after their completion. They could be freed by then.
-		rb_gc_mark(worker->thread);  // thread objects are currently pinned anyway
-		worker = next;
+		rb_gc_mark_movable(worker->thread);
+		worker = worker->next;
+	}
+}
+
+static void worker_pool_compact(void *ptr)
+{
+	struct IO_Event_WorkerPool *pool = (struct IO_Event_WorkerPool *)ptr;
+	struct IO_Event_WorkerPool_Worker *worker = pool->workers;
+	while (worker) {
+		worker->thread = rb_gc_location(worker->thread);
+		worker = worker->next;
 	}
 }
 
@@ -107,8 +116,8 @@ static size_t worker_pool_size(const void *ptr) {
 // Ruby TypedData structures
 static const rb_data_type_t IO_Event_WorkerPool_type = {
 	"IO::Event::WorkerPool",
-	{worker_pool_mark, worker_pool_free, worker_pool_size,},
-	0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+	{worker_pool_mark, worker_pool_free, worker_pool_size, worker_pool_compact},
+	0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 // Helper function to enqueue work (must be called with mutex held)


### PR DESCRIPTION
Three corrections to make `WorkerPool` a better citizen of the compacting and generational GC. None of these affects observed single-cycle behaviour; they are correctness/hygiene improvements rather than bug fixes.

### `worker_pool_compact`

A new compact callback that updates each worker's `thread` VALUE via `rb_gc_location`. Without this, a Thread object moved by the compacting GC would leave a stale reference in the worker struct.

### `rb_gc_mark_movable` for `worker->thread`

Previously `rb_gc_mark`, which pins the object. Marking movable lets the compacting GC relocate Thread objects, in concert with the new compact callback.

### `RUBY_TYPED_WB_PROTECTED`

Enables the write barrier on the `WorkerPool` TypedData. The existing `RB_OBJ_WRITE` at worker creation was a no-op without this flag; adding it makes generational and incremental GC correct.

---

**Not the use-after-free fix.** The crash that the original framing of this PR alluded to is a separate issue — a suspended fiber held by no external root — and is fixed in #174. These changes stand on their own.