### PR TITLE
Ensure _blocking_operation stays on the stack.

### DIFF
--- a/ext/io/event/worker_pool.c
+++ b/ext/io/event/worker_pool.c
@@ -375,6 +375,8 @@ static VALUE worker_pool_call(VALUE self, VALUE _blocking_operation) {
 	
 	if (DEBUG) fprintf(stderr, "<- worker_pool_call:work completed=%d, state=%d\n", work.completed, state);
 	
+	RB_GC_GUARD(_blocking_operation);
+	
 	if (state) {
 		rb_jump_tag(state);
 	} else {


### PR DESCRIPTION
`worker_pool` does not seem to be retaining the blocking operation correctly. Let's try to fix it.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
