### PR TITLE
Keep blocked scheduler fibers alive during GC

### DIFF
--- a/fixtures/io/event/test_scheduler.rb
+++ b/fixtures/io/event/test_scheduler.rb
@@ -41,6 +41,7 @@ module IO::Event
 			
 			# Track the number of fibers that are blocked.
 			@blocked = 0
+			@blocking = {}
 		end
 		
 		# @attribute [WorkerPool] The worker pool used for executing blocking operations.
@@ -80,8 +81,10 @@ module IO::Event
 			
 			begin
 				@blocked += 1
+				@blocking[fiber] = true
 				@selector.transfer
 			ensure
+				@blocking.delete(fiber)
 				@blocked -= 1
 			end
 		ensure

--- a/test/io/event/worker_pool.rb
+++ b/test/io/event/worker_pool.rb
@@ -122,35 +122,35 @@ describe IO::Event::WorkerPool do
 			expect(result[:result]).to be == :completed
 			expect(result[:duration]).to be == 0.05
 		end
-
+		
 		it "keeps blocked fibers alive during garbage collection" do
 			result = nil
-
+			
 			Thread.new do
 				Fiber.set_scheduler(scheduler)
-
+				
 				gc_thread = Thread.new do
 					sleep(0.02)
 					GC.start(full_mark: true, immediate_sweep: true)
 				end
-
+				
 				Fiber.schedule do
 					result = IO::Event::WorkerPool.busy(duration: 0.1)
 				end
-
+				
 				scheduler.run
 				gc_thread.value
 			ensure
 				Fiber.set_scheduler(nil)
 				scheduler.close
 			end.value
-
+			
 			expect(result).to have_keys(
 				cancelled: be == false,
 				result: be == :completed
 			)
 		end
-
+		
 		it "can cancel a busy operation using unblock function" do
 			# This tests the cancellation mechanism through rb_thread_call_without_gvl
 			completed = false

--- a/test/io/event/worker_pool.rb
+++ b/test/io/event/worker_pool.rb
@@ -122,7 +122,35 @@ describe IO::Event::WorkerPool do
 			expect(result[:result]).to be == :completed
 			expect(result[:duration]).to be == 0.05
 		end
-		
+
+		it "keeps blocked fibers alive during garbage collection" do
+			result = nil
+
+			Thread.new do
+				Fiber.set_scheduler(scheduler)
+
+				gc_thread = Thread.new do
+					sleep(0.02)
+					GC.start(full_mark: true, immediate_sweep: true)
+				end
+
+				Fiber.schedule do
+					result = IO::Event::WorkerPool.busy(duration: 0.1)
+				end
+
+				scheduler.run
+				gc_thread.value
+			ensure
+				Fiber.set_scheduler(nil)
+				scheduler.close
+			end.value
+
+			expect(result).to have_keys(
+				cancelled: be == false,
+				result: be == :completed
+			)
+		end
+
 		it "can cancel a busy operation using unblock function" do
 			# This tests the cancellation mechanism through rb_thread_call_without_gvl
 			completed = false


### PR DESCRIPTION
## Summary

- Keep fibers suspended in `TestScheduler#block` strongly referenced until the block resumes.
- Add a worker-pool regression test that forces GC while a blocking operation is active.

## Tests

- `docker run --platform linux/amd64 --rm -e EXPECT_CRASH=0 -v "$PWD:/io-event" -w /io-event io-event-ruby-gc-repro:amd64 repro/run-direct-repro.sh`
- `docker run --platform linux/amd64 --rm -v "$PWD:/io-event" -w /io-event io-event-ruby-gc-repro:amd64 sh -lc 'gem install bundler --no-document && bundle install && bundle exec bake build && bundle exec sus test/io/event/worker_pool.rb'`