### PR TITLE
Fix pure Ruby selector io_wait nil return

### DIFF
--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -159,7 +159,7 @@ module IO::Event
 			def io_wait(fiber, io, events)
 				waiter = @waiting[io] = Waiter.new(fiber, events, @waiting[io])
 				
-				@loop.transfer
+				@loop.transfer || false
 			ensure
 				waiter&.invalidate
 			end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Ensure the pure Ruby `Select` selector returns `false`, not `nil`, when `io_wait` resumes without any ready events.
+
 ## v1.16.0
 
   - Use `eventfd` for `URing` cross-thread wakeup, and enable `IORING_SETUP_SINGLE_ISSUER`, `IORING_SETUP_DEFER_TASKRUN`, and `IORING_SETUP_TASKRUN_FLAG`. The waking thread now signals via `eventfd` rather than submitting a `NOP` SQE, which unlocks the single-issuer optimisation, defers task work to the application thread, and lets `select()` skip the `io_uring_get_events()` syscall when no task work is pending.

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -123,6 +123,26 @@ Selector = Sus::Shared("a selector") do
 		let(:local) {sockets.first}
 		let(:remote) {sockets.last}
 		
+		it "does not return nil when resumed without events" do
+			sockets = UNIXSocket.pair
+			local = sockets.first
+			
+			result = :unset
+			
+			fiber = Fiber.new do
+				result = selector.io_wait(Fiber.current, local, IO::READABLE)
+			end
+			
+			fiber.transfer
+			fiber.transfer
+			
+			expect(result).to be == false
+		ensure
+			sockets&.each do |socket|
+				socket.close unless socket.closed?
+			end
+		end
+		
 		it "can wait for an io to become readable" do
 			fiber = Fiber.new do
 				events << :wait_readable


### PR DESCRIPTION
## Summary

- Return `false` from the pure Ruby `Select#io_wait` when the scheduler loop resumes without an event mask.
- Add a regression test covering the no-event resume path so `io_wait` does not leak `nil` to scheduler callers.

## Testing

- `bundle exec sus`
