### PR TITLE
Prevent unbounded PriorityHeap growth of cancelled timers

### DIFF
--- a/lib/io/event/priority_heap.rb
+++ b/lib/io/event/priority_heap.rb
@@ -44,17 +44,21 @@ class IO
 				
 				# If we have only one item, no swapping is required:
 				if @contents.size == 1
-					return @contents.pop
+					value = @contents.pop
+					set_heap_index(value, nil)
+					return value
 				end
 				
 				# Take the root of the tree:
 				value = @contents[0]
+				set_heap_index(value, nil)
 				
 				# Remove the last item in the tree:
 				last = @contents.pop
 				
 				# Overwrite the root of the tree with the item:
 				@contents[0] = last
+				set_heap_index(last, 0)
 				
 				# Bubble it down into place:
 				bubble_down(0)
@@ -70,6 +74,7 @@ class IO
 			def push(element)
 				# Insert the item at the end of the heap:
 				@contents.push(element)
+				set_heap_index(element, @contents.size - 1)
 				
 				# Bubble it up into position:
 				bubble_up(@contents.size - 1)
@@ -89,6 +94,7 @@ class IO
 				
 				# Add all elements to the array without maintaining heap property - O(n)
 				@contents.concat(elements)
+				update_heap_indices!
 				
 				# Rebuild the heap property for the entire array - O(n)
 				heapify!
@@ -98,31 +104,35 @@ class IO
 			
 			# Empties out the heap, discarding all elements
 			def clear!
+				@contents.each{|element| set_heap_index(element, nil)}
 				@contents = []
 			end
 			
 			# Remove a specific element from the heap.
 			#
-			# O(n) where n is the number of elements in the heap.
+			# O(log n) when the element tracks its heap index, otherwise O(n).
 			#
 			# @parameter element [Object] The element to remove.
 			# @returns [Object | Nil] The removed element, or nil if not found.
 			def delete(element)
-				# Find the index of the element - O(n) linear search
-				index = @contents.index(element)
+				index = heap_index_for(element)
 				return nil unless index
 				
 				# If it's the last element, just remove it
 				if index == @contents.size - 1
-					return @contents.pop
+					removed_value = @contents.pop
+					set_heap_index(removed_value, nil)
+					return removed_value
 				end
 				
 				# Store the value we're removing
 				removed_value = @contents[index]
+				set_heap_index(removed_value, nil)
 				
 				# Replace with the last element
 				last = @contents.pop
 				@contents[index] = last
+				set_heap_index(last, index)
 				
 				# Restore heap property - might need to bubble up or down
 				if index > 0 && @contents[index] < @contents[(index - 1) / 2]
@@ -150,12 +160,20 @@ class IO
 				return enum_for(:delete_if) unless block_given?
 				
 				original_size = @contents.size
+				removed = []
 				
 				# Filter out elements that match the condition - O(n)
-				@contents.reject!{|element| yield(element)}
+				@contents.reject! do |element|
+					if yield(element)
+						removed << element
+						true
+					end
+				end
 				
 				# If we removed elements, rebuild the heap - O(n)
 				if @contents.size < original_size
+					removed.each{|element| set_heap_index(element, nil)}
+					update_heap_indices!
 					heapify!
 				end
 				
@@ -170,6 +188,25 @@ class IO
 			end
 			
 			private
+			
+			def set_heap_index(element, index)
+				element.heap_index = index if element.respond_to?(:heap_index=)
+			end
+			
+			def update_heap_indices!
+				@contents.each_with_index{|element, index| set_heap_index(element, index)}
+			end
+			
+			def heap_index_for(element)
+				if element.respond_to?(:heap_index)
+					index = element.heap_index
+					
+					return index if index && @contents[index].equal?(element)
+				end
+				
+				# Fall back to an O(n) linear search when no valid heap_index is available.
+				@contents.index(element)
+			end
 			
 			# Rebuild the heap property from an arbitrary array in O(n) time.
 			# Uses bottom-up heapify algorithm starting from the last non-leaf node.
@@ -190,13 +227,18 @@ class IO
 			# 	@contents[i], @contents[j] = @contents[j], @contents[i]
 			# end
 			
+			def swap(i, j)
+				@contents[i], @contents[j] = @contents[j], @contents[i]
+				set_heap_index(@contents[i], i)
+				set_heap_index(@contents[j], j)
+			end
+			
 			def bubble_up(index)
 				parent_index = (index - 1) / 2 # watch out, integer division!
 				
 				while index > 0 && @contents[index] < @contents[parent_index]
 					# If the node has a smaller value than its parent, swap these nodes to uphold the minheap invariant and update the index of the 'current' node. If the node is already at index 0, we can also stop because that is the root of the heap.
-					# swap(index, parent_index)
-					@contents[index], @contents[parent_index] = @contents[parent_index], @contents[index]
+					swap(index, parent_index)
 					
 					index = parent_index
 					parent_index = (index - 1) / 2 # watch out, integer division!
@@ -233,8 +275,7 @@ class IO
 						return
 					else
 						# At least one of the child node has a smaller value than the current node, swap current node with that child and update current node for if it might need to bubble down even further:
-						# swap(index, swap_index)
-						@contents[index], @contents[swap_index] = @contents[swap_index], @contents[index]
+						swap(index, swap_index)
 						
 						index = swap_index
 					end

--- a/lib/io/event/timers.rb
+++ b/lib/io/event/timers.rb
@@ -14,10 +14,13 @@ class IO
 				# Initialize the handle with the given time and block.
 				#
 				# @parameter time [Float] The time at which the block should be called.
+				# @parameter heap [PriorityHeap] The heap used to schedule the timer.
 				# @parameter block [Proc] The block to call.
-				def initialize(time, block)
+				def initialize(time, heap, block)
 					@time = time
+					@heap = heap
 					@block = block
+					@heap_index = nil
 				end
 				
 				# @attribute [Float] The time at which the block should be called.
@@ -25,6 +28,9 @@ class IO
 				
 				# @attribute [Proc | Nil] The block to call when the timer fires.
 				attr :block
+				
+				# @attribute [Integer | Nil] The current index of the handle in the heap.
+				attr_accessor :heap_index
 				
 				# Compare the handle with another handle.
 				#
@@ -50,6 +56,10 @@ class IO
 				# Cancel the timer.
 				def cancel!
 					@block = nil
+					
+					if @heap_index
+						@heap.delete(self)
+					end
 				end
 				
 				# @returns [Boolean] Whether the timer has been cancelled.
@@ -76,7 +86,7 @@ class IO
 			# @parameter time [Float] The time at which the block should be called, relative to {#now}.
 			# @parameter block [Proc] The block to call.
 			def schedule(time, block)
-				handle = Handle.new(time, block)
+				handle = Handle.new(time, @heap, block)
 				
 				@scheduled << handle
 				

--- a/test/io/event/priority_heap.rb
+++ b/test/io/event/priority_heap.rb
@@ -5,8 +5,33 @@
 
 require "io/event/priority_heap"
 
+class IndexedPriorityHeapItem
+	include Comparable
+	
+	attr :value
+	attr_accessor :heap_index
+	
+	def initialize(value)
+		@value = value
+		@heap_index = nil
+	end
+	
+	def <=> other
+		@value <=> other.value
+	end
+end
+
 describe IO::Event::PriorityHeap do
 	let(:priority_heap) {subject.new}
+	
+	def expect_valid_heap_indices(priority_heap)
+		contents = priority_heap.instance_variable_get(:@contents)
+		
+		contents.each_with_index do |element, index|
+			expect(element.heap_index).to be == index
+			expect(contents[element.heap_index]).to be == element
+		end
+	end
 	
 	with "empty heap" do 
 		it "should return nil when the first element is requested" do
@@ -102,6 +127,50 @@ describe IO::Event::PriorityHeap do
 			test_values = (1..10).to_a + [4] * 5
 			test_values.each{|element| priority_heap.push(element)}
 			expect(priority_heap).to be(:valid?)
+		end
+	end
+	
+	with "indexed elements" do
+		it "tracks the current heap index for every element" do
+			items = [5, 2, 8, 1, 9, 3].map{|value| IndexedPriorityHeapItem.new(value)}
+			
+			items.each do |item|
+				priority_heap.push(item)
+				expect_valid_heap_indices(priority_heap)
+			end
+			
+			expect(priority_heap).to be(:valid?)
+		end
+		
+		it "clears heap indexes for removed elements" do
+			items = [5, 2, 8, 1, 9, 3].map{|value| IndexedPriorityHeapItem.new(value)}
+			items.each{|item| priority_heap.push(item)}
+			
+			removed = priority_heap.delete(items[1])
+			
+			expect(removed).to be == items[1]
+			expect(removed.heap_index).to be_nil
+			expect_valid_heap_indices(priority_heap)
+			
+			popped = priority_heap.pop
+			
+			expect(popped.heap_index).to be_nil
+			expect_valid_heap_indices(priority_heap)
+		end
+		
+		it "updates heap indexes when concatenating and deleting in bulk" do
+			items = (1..10).map{|value| IndexedPriorityHeapItem.new(value)}
+			
+			priority_heap.concat(items.shuffle)
+			expect_valid_heap_indices(priority_heap)
+			
+			removed_count = priority_heap.delete_if{|item| item.value.even?}
+			
+			expect(removed_count).to be == 5
+			items.select{|item| item.value.even?}.each do |item|
+				expect(item.heap_index).to be_nil
+			end
+			expect_valid_heap_indices(priority_heap)
 		end
 	end
 	

--- a/test/io/event/timers.rb
+++ b/test/io/event/timers.rb
@@ -77,6 +77,20 @@ describe IO::Event::Timers do
 		expect(timers.size).to be == 0
 	end
 	
+	it "should immediately remove cancelled timers from the heap" do
+		first = timers.after(0.1){}
+		timers.after(0.2){}
+		
+		expect(timers.size).to be == 2
+		expect(first.heap_index).not.to be_nil
+		
+		first.cancel!
+		
+		expect(first.heap_index).to be_nil
+		expect(timers.size).to be == 1
+		expect(timers.wait_interval).to be_within(0.01).of(0.2)
+	end
+	
 	with "#schedule" do
 		it "raises an error if given an invalid time" do
 			expect do


### PR DESCRIPTION
`Timers::Handle#cancel!` just sets `@block` to `nil` without removing it
from the `PriorityHeap`.  It will eventually be pruned when it reaches
the top of the heap, but that could take arbitrarily long.

Fix this by tracking the handle's index within the heap, and using it to
remove itself from the heap in O(log(n)) time when cancelled.

Co-authored-by: Codex <noreply@openai.com>

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
