### PR TITLE
Compact cancelled timers lazily.

### DIFF
--- a/lib/io/event/timers.rb
+++ b/lib/io/event/timers.rb
@@ -9,6 +9,8 @@ class IO
 	module Event
 		# An efficient sorted set of timers.
 		class Timers
+			COMPACT_MINIMUM_COUNT = 128
+			
 			# A handle to a scheduled timer.
 			class Handle
 				# Initialize the handle with the given time and block.
@@ -16,6 +18,7 @@ class IO
 				# @parameter time [Float] The time at which the block should be called.
 				# @parameter block [Proc] The block to call.
 				def initialize(time, block)
+					@timers = nil
 					@time = time
 					@block = block
 				end
@@ -25,6 +28,16 @@ class IO
 				
 				# @attribute [Proc | Nil] The block to call when the timer fires.
 				attr :block
+				
+				# Mark the timer as inserted into the heap.
+				def schedule!(timers)
+					@timers = timers
+				end
+				
+				# Mark the timer as removed from the heap.
+				def removed!
+					@timers = nil
+				end
 				
 				# Compare the handle with another handle.
 				#
@@ -49,7 +62,14 @@ class IO
 				
 				# Cancel the timer.
 				def cancel!
+					return if @block.nil?
+					
 					@block = nil
+					
+					if timers = @timers
+						@timers = nil
+						timers.cancelled!(self)
+					end
 				end
 				
 				# @returns [Boolean] Whether the timer has been cancelled.
@@ -62,11 +82,13 @@ class IO
 			def initialize
 				@heap = PriorityHeap.new
 				@scheduled = []
+				@cancelled = 0
 			end
 			
 			# @returns [Integer] The number of timers in the heap.
 			def size
 				flush!
+				compact!
 				
 				return @heap.size
 			end
@@ -97,10 +119,13 @@ class IO
 			# @returns [Float | Nil] The time interval until the next timer fires, if any.
 			def wait_interval(now = self.now)
 				flush!
+				compact!
 				
 				while handle = @heap.peek
 					if handle.cancelled?
 						@heap.pop
+						handle.removed!
+						@cancelled -= 1 if @cancelled > 0
 					else
 						return handle.time - now
 					end
@@ -118,14 +143,18 @@ class IO
 			def fire(now = self.now)
 				# Flush scheduled timers into the heap:
 				flush!
+				compact!
 				
 				# Get the earliest timer:
 				while handle = @heap.peek
 					if handle.cancelled?
 						@heap.pop
+						handle.removed!
+						@cancelled -= 1 if @cancelled > 0
 					elsif handle.time <= now
 						# Remove the earliest timer from the heap:
 						@heap.pop
+						handle.removed!
 						
 						# Call the block:
 						handle.call(now)
@@ -140,8 +169,34 @@ class IO
 			# This is a small optimization which assumes that most timers (timeouts) will be cancelled.
 			protected def flush!
 				while handle = @scheduled.pop
-					@heap.push(handle) unless handle.cancelled?
+					unless handle.cancelled?
+						handle.schedule!(self)
+						@heap.push(handle)
+					end
 				end
+			end
+			
+			# Periodically rebuild the heap when cancelled timers become a large
+			# enough fraction of the heap to risk unbounded retention or pruning spikes.
+			protected def compact!
+				if @cancelled == @heap.size
+					@heap.clear!
+					@cancelled = 0
+				elsif @cancelled >= COMPACT_MINIMUM_COUNT && @cancelled * 2 > @heap.size
+					@heap.delete_if do |handle|
+						if handle.cancelled?
+							handle.removed!
+							true
+						end
+					end
+					
+					@cancelled = 0
+				end
+			end
+			
+			# Track cancelled timers that are still retained in the heap.
+			def cancelled!(handle)
+				@cancelled += 1
 			end
 		end
 	end

--- a/test/io/event/timers.rb
+++ b/test/io/event/timers.rb
@@ -77,6 +77,57 @@ describe IO::Event::Timers do
 		expect(timers.size).to be == 0
 	end
 	
+	it "should compact cancelled timers from the heap" do
+		now = timers.now
+		count = subject::COMPACT_MINIMUM_COUNT
+		handles = count.times.map do |index|
+			timers.schedule(now + index, proc{})
+		end
+		
+		expect(timers.size).to be == count
+		
+		handles.each(&:cancel!)
+		
+		expect(timers.size).to be == 0
+	end
+	
+	it "should not compact half-cancelled timers from the heap" do
+		now = timers.now
+		count = subject::COMPACT_MINIMUM_COUNT
+		handles = (count * 2).times.map do |index|
+			timers.schedule(now + index, proc{})
+		end
+		
+		expect(timers.size).to be == count * 2
+		
+		handles.first(count).each(&:cancel!)
+		
+		expect(timers.size).to be == count * 2
+	end
+	
+	it "should compact more than half-cancelled timers from the heap" do
+		now = timers.now
+		count = subject::COMPACT_MINIMUM_COUNT
+		handles = (count * 2).times.map do |index|
+			timers.schedule(now + index, proc{})
+		end
+		
+		expect(timers.size).to be == count * 2
+		
+		handles.first(count + 1).each(&:cancel!)
+		
+		expect(timers.size).to be == count - 1
+	end
+	
+	it "should allow fired timers to be cancelled" do
+		handle = timers.after(0.1){}
+		
+		timers.fire(timers.now + 0.2)
+		handle.cancel!
+		
+		expect(timers.size).to be == 0
+	end
+	
 	with "#schedule" do
 		it "raises an error if given an invalid time" do
 			expect do


### PR DESCRIPTION
This is an alternative to #180 that keeps timer cancellation O(1) and bounds retained cancelled heap entries by rebuilding the heap when cancelled entries become at least half of the heap.

The benchmark added on main in 18296fa can be run with:

```sh
BUNDLE_WITH='' bundle exec sus --verbose benchmark/timers.rb
```

Local benchmark comparison on this machine, 10k timers / 16 samples:

| Scenario | main | #180 deletion branch | this branch |
| --- | ---: | ---: | ---: |
| schedule and flush 10000 timers | 13.27ms | 23.84ms | 14.19ms |
| cancel 10000 timers before flush | 2.93ms | 3.01ms | 3.18ms |
| cancel 10000 timers after flush | 13.44ms | 49.89ms | 14.48ms |
| schedule/flush after 10000 cancelled heap timers | 28.17ms | 73.07ms | 32.58ms |
| wait interval with 10000 cancelled heap timers | 28.16ms | 49.89ms | 14.81ms |

The numbers include setup inside each benchmark sample, so they are best used directionally. The main tradeoff is that this branch preserves cheap cancellation while bounding the worst lazy-pruning spike with amortized compaction.

Tests run:

```sh
BUNDLE_WITH='' bundle exec bake test
BUNDLE_WITH='' bundle exec sus --verbose benchmark/timers.rb
git diff --check
```