### PR TITLE
Optimize timer flushing.

### DIFF
--- a/lib/io/event/priority_heap.rb
+++ b/lib/io/event/priority_heap.rb
@@ -88,6 +88,7 @@ class IO
 			def concat(elements)
 				return self if elements.empty?
 				
+				# Rebuilding the whole heap is `O(n + m)`, where `n` is the existing heap size and `m` is the appended batch size. Incremental `push` is `O(m log(n))`, but is often closer to `O(m)` when appended elements are later than the existing entries and do not bubble far. Prefer `heapify` only when building from empty or when the batch dominates the existing heap.
 				if @contents.empty? || elements.size > @contents.size * HEAPIFY_INSERT_RATIO
 					@contents.concat(elements)
 					heapify!
@@ -100,15 +101,14 @@ class IO
 			
 			# Mutate the heap contents directly, then rebuild the heap property.
 			#
-			# This supports batched operations that can be completed with a single
-			# O(n) heapify instead of multiple O(log n) heap operations.
+			# This supports batched operations that can be completed with a single `O(n)` heapify instead of multiple `O(log n)` heap operations.
 			#
 			# @yields {|contents| ...} The heap contents array.
 			# @returns [self] Returns self for method chaining.
 			def heapify
 				yield @contents
 				
-				# Rebuild the heap property for the entire array - O(n).
+				# The block may arbitrarily append, delete or reorder contents, so repair the invariant with one `O(n)` bottom-up heapify pass.
 				heapify!
 				
 				return self

--- a/lib/io/event/priority_heap.rb
+++ b/lib/io/event/priority_heap.rb
@@ -10,6 +10,8 @@ class IO
 		# of its contents to determine priority.
 		# See <https://en.wikipedia.org/wiki/Binary_heap> for explanations of the main methods.
 		class PriorityHeap
+			HEAPIFY_INSERT_RATIO = 2
+			
 			# Initializes the heap.
 			def initialize
 				# The heap is represented with an array containing a binary tree. See
@@ -79,18 +81,33 @@ class IO
 				return self
 			end
 			
-			# Add multiple elements to the heap efficiently in O(n) time.
-			# This is more efficient than calling push multiple times (O(n log n)).
+			# Add multiple elements to the heap efficiently.
 			#
 			# @parameter elements [Array] The elements to add to the heap.
 			# @returns [self] Returns self for method chaining.
 			def concat(elements)
 				return self if elements.empty?
 				
-				# Add all elements to the array without maintaining heap property - O(n)
-				@contents.concat(elements)
+				if @contents.empty? || elements.size > @contents.size * HEAPIFY_INSERT_RATIO
+					@contents.concat(elements)
+					heapify!
+				else
+					elements.each{|element| push(element)}
+				end
 				
-				# Rebuild the heap property for the entire array - O(n)
+				return self
+			end
+			
+			# Mutate the heap contents directly, then rebuild the heap property.
+			#
+			# This supports batched operations that can be completed with a single
+			# O(n) heapify instead of multiple O(log n) heap operations.
+			#
+			# @yields {|contents| ...} The heap contents array.
+			# @returns [self] Returns self for method chaining.
+			def heapify
+				yield @contents
+				
 				heapify!
 				
 				return self

--- a/lib/io/event/priority_heap.rb
+++ b/lib/io/event/priority_heap.rb
@@ -108,6 +108,7 @@ class IO
 			def heapify
 				yield @contents
 				
+				# Rebuild the heap property for the entire array - O(n).
 				heapify!
 				
 				return self

--- a/lib/io/event/timers.rb
+++ b/lib/io/event/timers.rb
@@ -165,9 +165,6 @@ class IO
 			#
 			# This is a small optimization which assumes that most timers (timeouts) will be cancelled.
 			protected def flush!
-				scheduled = @scheduled
-				@scheduled = []
-				
 				if @cancelled >= COMPACT_MINIMUM_COUNT && @cancelled * 2 > @heap.size
 					@heap.heapify do |contents|
 						contents.delete_if do |handle|
@@ -177,12 +174,17 @@ class IO
 							end
 						end
 						
-						append_scheduled!(scheduled, contents)
+						@scheduled.each do |handle|
+							unless handle.cancelled?
+								handle.schedule!(self)
+								contents << handle
+							end
+						end
 					end
 					
 					@cancelled = 0
 				else
-					scheduled.delete_if do |handle|
+					@scheduled.delete_if do |handle|
 						if handle.cancelled?
 							true
 						else
@@ -191,28 +193,15 @@ class IO
 						end
 					end
 					
-					if @cancelled == @heap.size && scheduled.empty?
+					if @cancelled == @heap.size && @scheduled.empty?
 						@heap.clear!
 						@cancelled = 0
 					else
-						@heap.concat(scheduled)
+						@heap.concat(@scheduled)
 					end
 				end
-			end
-			
-			def append_scheduled!(scheduled, target)
-				index = 0
 				
-				while index < scheduled.size
-					handle = scheduled[index]
-					
-					unless handle.cancelled?
-						handle.schedule!(self)
-						target << handle
-					end
-					
-					index += 1
-				end
+				@scheduled.clear
 			end
 			
 			# Track cancelled timers that are still retained in the heap.

--- a/lib/io/event/timers.rb
+++ b/lib/io/event/timers.rb
@@ -163,8 +163,9 @@ class IO
 			
 			# Flush all scheduled timers into the heap.
 			#
-			# This is a small optimization which assumes that most timers (timeouts) will be cancelled.
+			# Scheduling appends to `@scheduled` and cancellation is `O(1)`. We pay the cost of filtering and heap repair here, where we can batch work and choose between incremental insertion and one `heapify` pass.
 			protected def flush!
+				# Once cancelled handles are both numerous and a large fraction of the heap, rebuild the heap. This is `O(n + m)`, but it removes retained cancelled handles and appends live scheduled handles in the same `heapify` pass instead of paying for separate filtering and insertion.
 				if @cancelled >= COMPACT_MINIMUM_COUNT && @cancelled * 2 > @heap.size
 					@heap.heapify do |contents|
 						contents.delete_if do |handle|
@@ -184,6 +185,7 @@ class IO
 					
 					@cancelled = 0
 				else
+					# If we are not compacting the heap, filter scheduled handles in place before insertion. This keeps cancelled scheduled handles out of the heap without adding cancellation-time heap deletion.
 					@scheduled.delete_if do |handle|
 						if handle.cancelled?
 							true
@@ -193,6 +195,7 @@ class IO
 						end
 					end
 					
+					# Small heaps can become entirely cancelled before reaching the compaction threshold. Clear those immediately so `size` does not retain cancelled handles indefinitely.
 					if @cancelled == @heap.size && @scheduled.empty?
 						@heap.clear!
 						@cancelled = 0

--- a/lib/io/event/timers.rb
+++ b/lib/io/event/timers.rb
@@ -88,7 +88,6 @@ class IO
 			# @returns [Integer] The number of timers in the heap.
 			def size
 				flush!
-				compact!
 				
 				return @heap.size
 			end
@@ -119,7 +118,6 @@ class IO
 			# @returns [Float | Nil] The time interval until the next timer fires, if any.
 			def wait_interval(now = self.now)
 				flush!
-				compact!
 				
 				while handle = @heap.peek
 					if handle.cancelled?
@@ -143,7 +141,6 @@ class IO
 			def fire(now = self.now)
 				# Flush scheduled timers into the heap:
 				flush!
-				compact!
 				
 				# Get the earliest timer:
 				while handle = @heap.peek
@@ -168,29 +165,53 @@ class IO
 			#
 			# This is a small optimization which assumes that most timers (timeouts) will be cancelled.
 			protected def flush!
-				while handle = @scheduled.pop
-					unless handle.cancelled?
-						handle.schedule!(self)
-						@heap.push(handle)
+				scheduled = @scheduled
+				@scheduled = []
+				
+				if @cancelled >= COMPACT_MINIMUM_COUNT && @cancelled * 2 > @heap.size
+					@heap.heapify do |contents|
+						contents.delete_if do |handle|
+							if handle.cancelled?
+								handle.removed!
+								true
+							end
+						end
+						
+						append_scheduled!(scheduled, contents)
+					end
+					
+					@cancelled = 0
+				else
+					scheduled.delete_if do |handle|
+						if handle.cancelled?
+							true
+						else
+							handle.schedule!(self)
+							false
+						end
+					end
+					
+					if @cancelled == @heap.size && scheduled.empty?
+						@heap.clear!
+						@cancelled = 0
+					else
+						@heap.concat(scheduled)
 					end
 				end
 			end
 			
-			# Periodically rebuild the heap when cancelled timers become a large
-			# enough fraction of the heap to risk unbounded retention or pruning spikes.
-			protected def compact!
-				if @cancelled == @heap.size
-					@heap.clear!
-					@cancelled = 0
-				elsif @cancelled >= COMPACT_MINIMUM_COUNT && @cancelled * 2 > @heap.size
-					@heap.delete_if do |handle|
-						if handle.cancelled?
-							handle.removed!
-							true
-						end
+			def append_scheduled!(scheduled, target)
+				index = 0
+				
+				while index < scheduled.size
+					handle = scheduled[index]
+					
+					unless handle.cancelled?
+						handle.schedule!(self)
+						target << handle
 					end
 					
-					@cancelled = 0
+					index += 1
 				end
 			end
 			

--- a/test/io/event/priority_heap.rb
+++ b/test/io/event/priority_heap.rb
@@ -8,7 +8,7 @@ require "io/event/priority_heap"
 describe IO::Event::PriorityHeap do
 	let(:priority_heap) {subject.new}
 	
-	with "empty heap" do 
+	with "empty heap" do
 		it "should return nil when the first element is requested" do
 			expect(priority_heap.peek).to be_nil
 		end
@@ -571,6 +571,27 @@ describe IO::Event::PriorityHeap do
 				sorted << priority_heap.pop
 			end
 			expect(sorted).to be == [1, 5, 8, 10, 15]
+		end
+	end
+	
+	with "#heapify" do
+		it "should allow batched mutation of heap contents" do
+			priority_heap.concat([1, 2, 3, 4, 5])
+			
+			result = priority_heap.heapify do |contents|
+				contents.delete_if{|element| element.even?}
+				contents.concat([6, 7])
+			end
+			
+			expect(result).to be == priority_heap
+			expect(priority_heap).to be(:valid?)
+			
+			values = []
+			while !priority_heap.empty?
+				values << priority_heap.pop
+			end
+			
+			expect(values).to be == [1, 3, 5, 6, 7]
 		end
 	end
 end


### PR DESCRIPTION
## Summary

- Add `PriorityHeap#heapify { |contents| ... }` for batched heap mutation followed by a single heap rebuild.
- Fold timer heap compaction into `Timers#flush!` so scheduled additions and cancelled-handle removal can share the same heapify pass.
- Let `PriorityHeap#concat` choose between incremental `push` and full heapify based on the existing heap size and batch size.
- Keep `Handle#cancel!` O(1) while still bounding retained cancelled timers.

## Rationale

This keeps cancellation cheap and moves the expensive work to flush/compact points where we have more context:

- all cancelled heap + no additions: clear the heap;
- compacting heap + scheduled additions: delete cancelled handles and append live scheduled handles inside one `heapify` block;
- scheduled-only additions: call `PriorityHeap#concat`, which uses incremental `push` for normal batches and heapify only for empty heaps or very large batches.

## Local benchmark comparison

Benchmarked with the same standalone timer script on each ref using Ruby 4.0.5. Values are mean milliseconds over 24 measured samples after 4 warmup samples; lower is better. `main` already includes #181, but both are listed for completeness.

| Benchmark | main | #180 | #181 | #182 |
| --- | ---: | ---: | ---: | ---: |
| Schedule and flush 10k timers | 12.603ms | 22.420ms | 12.813ms | 2.559ms |
| Cancel 10k timers before flush | 2.120ms | 2.078ms | 2.153ms | 2.179ms |
| Cancel 10k timers after flush | 13.279ms | 48.551ms | 13.502ms | 3.186ms |
| Schedule/flush after 10k cancelled heap timers | 28.451ms | 71.476ms | 28.937ms | 6.976ms |
| Wait interval with 10k cancelled heap timers | 13.235ms | 48.783ms | 13.486ms | 3.581ms |

Standard deviations were low in this run:

| Benchmark | main | #180 | #181 | #182 |
| --- | ---: | ---: | ---: | ---: |
| Schedule and flush 10k timers | 0.104ms | 0.108ms | 0.204ms | 0.026ms |
| Cancel 10k timers before flush | 0.044ms | 0.043ms | 0.026ms | 0.037ms |
| Cancel 10k timers after flush | 0.050ms | 0.552ms | 0.209ms | 0.044ms |
| Schedule/flush after 10k cancelled heap timers | 0.164ms | 0.253ms | 0.336ms | 0.144ms |
| Wait interval with 10k cancelled heap timers | 0.089ms | 0.463ms | 0.211ms | 0.065ms |

## Tests

- `BUNDLE_WITH='' bundle exec rubocop lib/io/event/timers.rb lib/io/event/priority_heap.rb test/io/event/timers.rb test/io/event/priority_heap.rb`
- `BUNDLE_WITH='' bundle exec sus test/io/event/timers.rb test/io/event/priority_heap.rb`
- `BUNDLE_WITH='' bundle exec bake test`