### PR TITLE
Add priority heap benchmarks

### DIFF
--- a/benchmark/io/event/priority_heap.rb
+++ b/benchmark/io/event/priority_heap.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "sus/fixtures/benchmark"
+require "io/event/priority_heap"
+
+describe IO::Event::PriorityHeap do
+	include Sus::Fixtures::Benchmark
+	
+	let(:entries) {(0...10_000).to_a}
+	let(:append_entries) {(10_000...15_000).to_a}
+	
+	def build_heap(entries)
+		heap = subject.new
+		heap.concat(entries)
+		return heap
+	end
+	
+	measure "push in-order entries" do |repeats|
+		heap = subject.new
+		index = 0
+		
+		repeats.times do
+			heap.push(index)
+			index += 1
+		end
+	end
+	
+	measure "push reverse-order entries" do |repeats|
+		heap = subject.new
+		index = 0
+		
+		repeats.times do
+			heap.push(-index)
+			index += 1
+		end
+	end
+	
+	measure "concat entries into empty heap" do |repeats|
+		repeats.times do
+			heap = subject.new
+			heap.concat(entries)
+		end
+	end
+	
+	measure "pop entries" do |repeats|
+		heap = build_heap(entries)
+		
+		repeats.times do
+			if heap.empty?
+				heap.concat(entries)
+			end
+			
+			heap.pop
+		end
+	end
+	
+	measure "heapify after deleting half and appending half" do |repeats|
+		repeats.times do
+			heap = build_heap(entries)
+			
+			heap.heapify do |contents|
+				contents.delete_if{|element| element.even?}
+				contents.concat(append_entries)
+			end
+		end
+	end
+	
+	measure "delete_if half the entries" do |repeats|
+		repeats.times do
+			heap = build_heap(entries)
+			
+			heap.delete_if do |element|
+				element.even?
+			end
+		end
+	end
+end


### PR DESCRIPTION
## Summary

- Add `benchmark/io/event/priority_heap.rb` using `sus-fixtures-benchmark`.
- Cover priority heap `push`, `concat`, `pop`, `heapify`, and `delete_if` workloads.
- Capture the findings from evaluating a targeted native extension prototype against Ruby and YJIT.

## Findings

A targeted native prototype patched the hot `PriorityHeap` methods from the extension. It improved plain Ruby in several heap-heavy paths, but YJIT generally performed better without adding C maintenance or load-order complexity. The native prototype is not included in this PR; this PR keeps the benchmark so future changes can be evaluated consistently.

Local benchmark results from `benchmark/io/event/priority_heap.rb`:

| Benchmark | Ruby | Ruby + YJIT | Native Prototype |
| --- | ---: | ---: | ---: |
| `push` in-order | 573.35ns | 469.49ns | 512.48ns |
| `push` reverse-order | 1.19us | 752.48ns | 695.09ns |
| `concat` into empty heap | 467.75us | 81.11us | 131.37us |
| `pop` | 1.97us | 757.72ns | 861.19ns |
| `heapify` after delete/append | 1.17ms | 335.63us | 485.32us |
| `delete_if` half | 1.05ms | 383.57us | 420.06us |

Conclusion: YJIT is the better optimization path for the current Ruby heap implementation. A native implementation does not look like a net win unless non-YJIT performance becomes important enough to justify maintaining duplicate heap logic in C.

## Verification

- `BUNDLE_WITH='' bundle exec rubocop benchmark/io/event/priority_heap.rb`
- `BUNDLE_WITH='' bundle exec sus --verbose benchmark/io/event/priority_heap.rb`
- `BUNDLE_WITH='' bundle exec ruby --yjit -S sus --verbose benchmark/io/event/priority_heap.rb`