### PR TITLE
Fix epoll_pwait2 feature detection

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -55,7 +55,7 @@ have_func("rb_io_descriptor")
 have_func("&rb_process_status_wait")
 have_func("rb_fiber_current")
 have_func("&rb_fiber_raise")
-have_func("epoll_pwait2") if enable_config("epoll_pwait2", true)
+have_func("epoll_pwait2(0, 0, 0, 0, 0)", "sys/epoll.h") if enable_config("epoll_pwait2", true)
 
 have_header("ruby/io/buffer.h")
 


### PR DESCRIPTION
# TL;DR

Fix `epoll_pwait2` feature detection so Android/Termux can fall back to `epoll_wait` when the header does not declare `epoll_pwait2`.

# Context

Closes https://github.com/socketry/io-event/issues/155

The reported Termux build has a linkable `epoll_pwait2` symbol, so mkmf's bare `have_func("epoll_pwait2")` probe can define `HAVE_EPOLL_PWAIT2`. However, Android's `<sys/epoll.h>` in that environment does not declare `epoll_pwait2`, so compiling `epoll.c` fails with an implicit function declaration error under C99.

# Changes

The probe now checks an `epoll_pwait2(0, 0, 0, 0, 0)` call expression through `<sys/epoll.h>`. This keeps the generated macro as `HAVE_EPOLL_PWAIT2` while requiring the declaration to be visible to the compiler.

Platforms whose headers expose the API still use `epoll_pwait2`; Android/Termux configurations that only expose the symbol leave the macro undefined and continue using the existing `epoll_wait` fallback.

# Tophatting

- `bundle exec rubocop -A`
- `ruby ext/extconf.rb`

The local extconf run reports `checking for epoll_pwait2(0, 0, 0, 0, 0) in sys/epoll.h... no` on this machine, which matches the intended header-aware fallback behavior when the declaration is unavailable.
