### PR TITLE
Make coverage dependency optional for tests

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -7,6 +7,7 @@ permissions:
 
 env:
   COVERAGE: PartialSummary
+  BUNDLE_WITH: coverage
 
 jobs:
   test:

--- a/config/sus.rb
+++ b/config/sus.rb
@@ -7,8 +7,10 @@ require_relative "environment"
 
 Warning[:experimental] = false
 
-require "covered/sus"
-include Covered::Sus
+if ENV.key?("COVERAGE")
+	require "covered/sus"
+	include Covered::Sus
+end
 
 # Intensive GC checking:
 #

--- a/gems.rb
+++ b/gems.rb
@@ -20,7 +20,6 @@ end
 group :test do
 	gem "sus"
 	gem "sus-fixtures-benchmark"
-	gem "covered"
 	gem "decode"
 	
 	gem "rubocop"
@@ -30,4 +29,8 @@ group :test do
 	gem "bake-test"
 	gem "bake-test-external"
 	gem "async"
+end
+
+group :coverage, optional: true do
+	gem "covered"
 end


### PR DESCRIPTION
# TL;DR

Keep coverage tooling out of the default test bundle and install it only for the coverage workflow.

# Context

While following CI for another change, the plain `Test` workflow failed before running `io-event` tests because it installed `covered`/`ruby-coverage`, even though that workflow does not produce coverage artifacts. The failures came from the coverage dependency installation on JRuby/Windows rather than from this project’s test suite.

The `Test Coverage` workflow is the only workflow that needs `covered`.

# Changes

- Move `covered` into an optional `coverage` Bundler group.
- Load `covered/sus` only when `COVERAGE` is configured.
- Opt the `Test Coverage` workflow into the optional coverage group with `BUNDLE_WITH=coverage`.

# Tophatting

- `ruby -c config/sus.rb`
- `ruby -c gems.rb`
- `git diff --check`
