### PR TITLE
Interrupt fix.

### DIFF
--- a/lib/io/event/interrupt.rb
+++ b/lib/io/event/interrupt.rb
@@ -34,9 +34,9 @@ module IO::Event
 		end
 		
 		def close
+			@fiber.kill
 			@input.close
 			@output.close
-			# @fiber.raise(::Interrupt)
 		end
 	end
 	

--- a/lib/io/event/interrupt.rb
+++ b/lib/io/event/interrupt.rb
@@ -34,9 +34,9 @@ module IO::Event
 		end
 		
 		def close
-			@fiber.kill
-			@input.close
-			@output.close
+			@fiber.kill rescue nil
+			@input.close rescue nil
+			@output.close rescue nil
 		end
 	end
 	

--- a/lib/io/event/interrupt.rb
+++ b/lib/io/event/interrupt.rb
@@ -20,6 +20,8 @@ module IO::Event
 						@input.read_nonblock(1)
 					end
 				end
+			rescue IOError
+				# This is expected on shutdown.
 			end
 			
 			@fiber.transfer
@@ -34,9 +36,8 @@ module IO::Event
 		end
 		
 		def close
-			@fiber.kill rescue nil
-			@input.close rescue nil
-			@output.close rescue nil
+			@input.close
+			@output.close
 		end
 	end
 	

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Handle `IOError` raised while shutting down the pure Ruby interrupt pipe, so `IO::Event::Interrupt#close` does not leak expected shutdown errors from the interrupt fiber.
+
 ## v1.16.2
 
   - Improve timer heap performance by batching scheduled timer insertion, compacting cancelled timers during flush, and avoiding unnecessary heap rebuilds for small incremental inserts.

--- a/test/io/event/interrupt.rb
+++ b/test/io/event/interrupt.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "io/event/interrupt"
+
+describe IO::Event.const_get(:Interrupt) do
+	let(:loop) {Fiber.current}
+	
+	let(:selector) do
+		loop = self.loop
+		
+		Object.new.tap do |selector|
+			selector.define_singleton_method(:io_wait) do |fiber, io, events|
+				loop.transfer
+				
+				return true
+			end
+		end
+	end
+	
+	with "#close" do
+		it "handles IOError in the interrupt fiber" do
+			interrupt = subject.new(selector)
+			fiber = interrupt.instance_variable_get(:@fiber)
+			
+			interrupt.close
+			
+			expect do
+				fiber.transfer
+			end.not.to raise_exception(IOError)
+			
+			expect(fiber).not.to be(:alive?)
+		end
+	end
+end


### PR DESCRIPTION
On Ruby Head, having a fiber blow up with an `IOError` [causes chaos elsewhere](https://github.com/socketry/async/actions/runs/27990388040/job/82878807501?pr=456), and it was an expected failure/exception. So rescue and ignore it.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
