### PR TITLE
Fix Interrupt robustness.

### DIFF
--- a/fixtures/io/event/test_scheduler.rb
+++ b/fixtures/io/event/test_scheduler.rb
@@ -159,6 +159,13 @@ module IO::Event
 			timer&.cancel!
 		end
 		
+		def process_wait(pid, flags)
+			@blocked += 1
+			@selector.process_wait(Fiber.current, pid, flags)
+		ensure
+			@blocked -= 1
+		end
+		
 		def kernel_sleep(duration = nil)
 			if duration
 				self.block(nil, duration)

--- a/lib/io/event/interrupt.rb
+++ b/lib/io/event/interrupt.rb
@@ -14,6 +14,8 @@ module IO::Event
 			@selector = selector
 			@input, @output = ::IO.pipe
 			
+			@output.sync = true
+			
 			@fiber = Fiber.new do
 				while true
 					if @selector.io_wait(@fiber, @input, IO::READABLE)
@@ -27,12 +29,10 @@ module IO::Event
 			@fiber.transfer
 		end
 		
-		# Send a sigle byte interrupt.
+		# Send a single byte interrupt.
 		def signal
-			@output.write(".")
-			@output.flush
-		rescue IOError
-			# Ignore.
+			# This must not block or enter blocking operations or raise an exception.
+			@output.write_nonblock(".", exception: false)
 		end
 		
 		def close

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Correctly implement `Interrupt#signal` so that it is robust enough to be called by `Scheduler#unblock`.
+
 ## v1.16.3
 
   - Handle `IOError` raised while shutting down the pure Ruby interrupt pipe, so `IO::Event::Interrupt#close` does not leak expected shutdown errors from the interrupt fiber.

--- a/test/io/event/interrupt.rb
+++ b/test/io/event/interrupt.rb
@@ -3,7 +3,10 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
+require "io/event"
 require "io/event/interrupt"
+require "io/event/test_scheduler"
+require "io/nonblock"
 
 describe IO::Event.const_get(:Interrupt) do
 	let(:loop) {Fiber.current}
@@ -32,6 +35,37 @@ describe IO::Event.const_get(:Interrupt) do
 			end.not.to raise_exception(IOError)
 			
 			expect(fiber).not.to be(:alive?)
+		end
+	end
+	
+	with "test scheduler" do
+		it "can be used to wake up a fiber blocked in `Thread#join`" do
+			skip_unless_method_defined(:fork, Process.singleton_class)
+			
+			10.times do
+				r, w = IO.pipe
+				
+				Thread.new do
+					selector = IO::Event::Selector::Select.new(Fiber.current)
+					scheduler = IO::Event::TestScheduler.new(selector: selector)
+					Fiber.set_scheduler(scheduler)
+					
+					Fiber.schedule do
+						selector.dump_state($stderr, label: "interrupt fork before fork") if ENV["IO_EVENT_DIAGNOSTICS"]
+						
+						pid = Process.fork do
+							# Child process:
+							w.write("hello")
+						end
+						
+						# Parent process:
+						w.close
+						expect(r.read).to be == "hello"
+					ensure
+						Process.waitpid(pid) if pid
+					end
+				end.join
+			end
 		end
 	end
 end


### PR DESCRIPTION
It turns out that Interrupt#signal is problematic... I don't know why, but if an `IOError` is triggered during it's activation during `Thread#join`, Ruby's `blocking_operation` list seems to get messed up.