### PR TITLE
Avoid closing inherited selector descriptors

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -9,6 +9,7 @@
 #include <sys/epoll.h>
 #include <time.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include "pidfd.c"
 #include "../interrupt.h"
@@ -38,6 +39,7 @@ struct IO_Event_Selector_EPoll
 {
 	struct IO_Event_Selector backend;
 	int descriptor;
+	pid_t owner;
 	
 	// Flag indicating whether the selector is currently blocked in a system call.
 	// Set to 1 when blocked in epoll_wait() without GVL, 0 otherwise.
@@ -131,10 +133,12 @@ static
 void close_internal(struct IO_Event_Selector_EPoll *selector)
 {
 	if (selector->descriptor >= 0) {
-		close(selector->descriptor);
-		selector->descriptor = -1;
+		if (selector->owner == getpid()) {
+			close(selector->descriptor);
+			IO_Event_Interrupt_close(&selector->interrupt);
+		}
 		
-		IO_Event_Interrupt_close(&selector->interrupt);
+		selector->descriptor = -1;
 	}
 }
 
@@ -315,6 +319,7 @@ VALUE IO_Event_Selector_EPoll_allocate(VALUE self) {
 	
 	IO_Event_Selector_initialize(&selector->backend, self, Qnil);
 	selector->descriptor = -1;
+	selector->owner = 0;
 	selector->blocked = 0;
 	
 	selector->descriptors.element_initialize = IO_Event_Selector_EPoll_Descriptor_initialize;
@@ -350,6 +355,7 @@ VALUE IO_Event_Selector_EPoll_initialize(VALUE self, VALUE loop) {
 		rb_sys_fail("IO_Event_Selector_EPoll_initialize:epoll_create");
 	} else {
 		selector->descriptor = result;
+		selector->owner = getpid();
 		
 		rb_update_max_fd(selector->descriptor);
 	}
@@ -383,6 +389,13 @@ VALUE IO_Event_Selector_EPoll_close(VALUE self) {
 	close_internal(selector);
 	
 	return Qnil;
+}
+
+VALUE IO_Event_Selector_EPoll_closed_p(VALUE self) {
+	struct IO_Event_Selector_EPoll *selector = NULL;
+	TypedData_Get_Struct(self, struct IO_Event_Selector_EPoll, &IO_Event_Selector_EPoll_Type, selector);
+	
+	return selector->descriptor < 0 || selector->owner != getpid() ? Qtrue : Qfalse;
 }
 
 VALUE IO_Event_Selector_EPoll_transfer(VALUE self)
@@ -1087,6 +1100,7 @@ void Init_IO_Event_Selector_EPoll(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_EPoll, "select", IO_Event_Selector_EPoll_select, 1);
 	rb_define_method(IO_Event_Selector_EPoll, "wakeup", IO_Event_Selector_EPoll_wakeup, 0);
 	rb_define_method(IO_Event_Selector_EPoll, "close", IO_Event_Selector_EPoll_close, 0);
+	rb_define_method(IO_Event_Selector_EPoll, "closed?", IO_Event_Selector_EPoll_closed_p, 0);
 	
 	rb_define_method(IO_Event_Selector_EPoll, "io_wait", IO_Event_Selector_EPoll_io_wait, 3);
 	

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include <unistd.h>
 
 #include "../interrupt.h"
 
@@ -47,6 +48,7 @@ struct IO_Event_Selector_KQueue
 {
 	struct IO_Event_Selector backend;
 	int descriptor;
+	pid_t owner;
 	
 	// Flag indicating whether the selector is currently blocked in a system call.
 	// Set to 1 when blocked in kevent() without GVL, 0 otherwise.
@@ -132,7 +134,14 @@ static
 void close_internal(struct IO_Event_Selector_KQueue *selector)
 {
 	if (selector->descriptor >= 0) {
-		close(selector->descriptor);
+		if (selector->owner == getpid()) {
+			close(selector->descriptor);
+			
+#ifdef IO_EVENT_SELECTOR_KQUEUE_USE_INTERRUPT
+			IO_Event_Interrupt_close(&selector->interrupt);
+#endif
+		}
+		
 		selector->descriptor = -1;
 	}
 }
@@ -289,6 +298,7 @@ VALUE IO_Event_Selector_KQueue_allocate(VALUE self) {
 	
 	IO_Event_Selector_initialize(&selector->backend, self, Qnil);
 	selector->descriptor = -1;
+	selector->owner = 0;
 	selector->blocked = 0;
 	
 	selector->descriptors.element_initialize = IO_Event_Selector_KQueue_Descriptor_initialize;
@@ -331,6 +341,7 @@ VALUE IO_Event_Selector_KQueue_initialize(VALUE self, VALUE loop) {
 		ioctl(result, FIOCLEX);
 		
 		selector->descriptor = result;
+		selector->owner = getpid();
 		
 		rb_update_max_fd(selector->descriptor);
 	}
@@ -365,11 +376,14 @@ VALUE IO_Event_Selector_KQueue_close(VALUE self) {
 	
 	close_internal(selector);
 	
-#ifdef IO_EVENT_SELECTOR_KQUEUE_USE_INTERRUPT
-	IO_Event_Interrupt_close(&selector->interrupt);
-#endif
-	
 	return Qnil;
+}
+
+VALUE IO_Event_Selector_KQueue_closed_p(VALUE self) {
+	struct IO_Event_Selector_KQueue *selector = NULL;
+	TypedData_Get_Struct(self, struct IO_Event_Selector_KQueue, &IO_Event_Selector_KQueue_Type, selector);
+	
+	return selector->descriptor < 0 || selector->owner != getpid() ? Qtrue : Qfalse;
 }
 
 VALUE IO_Event_Selector_KQueue_transfer(VALUE self)
@@ -1098,6 +1112,7 @@ void Init_IO_Event_Selector_KQueue(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_KQueue, "select", IO_Event_Selector_KQueue_select, 1);
 	rb_define_method(IO_Event_Selector_KQueue, "wakeup", IO_Event_Selector_KQueue_wakeup, 0);
 	rb_define_method(IO_Event_Selector_KQueue, "close", IO_Event_Selector_KQueue_close, 0);
+	rb_define_method(IO_Event_Selector_KQueue, "closed?", IO_Event_Selector_KQueue_closed_p, 0);
 	
 	rb_define_method(IO_Event_Selector_KQueue, "io_wait", IO_Event_Selector_KQueue_io_wait, 3);
 	

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "../interrupt.h"
 
@@ -32,6 +33,7 @@ struct IO_Event_Selector_URing
 {
 	struct IO_Event_Selector backend;
 	struct io_uring ring;
+	pid_t owner;
 	
 	// Flag indicating whether the selector is currently blocked in a system call.
 	// Set to 1 when blocked in io_uring_wait_cqe_timeout() without GVL, 0 otherwise.
@@ -115,14 +117,20 @@ void IO_Event_Selector_URing_Type_compact(void *_selector)
 static
 void close_internal(struct IO_Event_Selector_URing *selector)
 {
-	if (selector->interrupt.descriptor >= 0) {
-		IO_Event_Interrupt_close(&selector->interrupt);
+	if (selector->owner == getpid()) {
+		if (selector->interrupt.descriptor >= 0) {
+			IO_Event_Interrupt_close(&selector->interrupt);
+			selector->interrupt.descriptor = -1;
+			selector->wakeup_registered = 0;
+		}
+		
+		if (selector->ring.ring_fd >= 0) {
+			io_uring_queue_exit(&selector->ring);
+			selector->ring.ring_fd = -1;
+		}
+	} else {
 		selector->interrupt.descriptor = -1;
 		selector->wakeup_registered = 0;
-	}
-	
-	if (selector->ring.ring_fd >= 0) {
-		io_uring_queue_exit(&selector->ring);
 		selector->ring.ring_fd = -1;
 	}
 }
@@ -237,6 +245,7 @@ VALUE IO_Event_Selector_URing_allocate(VALUE self) {
 	
 	IO_Event_Selector_initialize(&selector->backend, self, Qnil);
 	selector->ring.ring_fd = -1;
+	selector->owner = 0;
 	
 	selector->blocked = 0;
 	selector->interrupt.descriptor = -1;
@@ -299,6 +308,8 @@ VALUE IO_Event_Selector_URing_initialize(VALUE self, VALUE loop) {
 		rb_syserr_fail(-result, "IO_Event_Selector_URing_initialize:io_uring_queue_init");
 	}
 	
+	selector->owner = getpid();
+	
 	rb_update_max_fd(selector->ring.ring_fd);
 	
 	// Interrupt for cross-thread wakeup: another thread calls signal(); the owner
@@ -337,6 +348,13 @@ VALUE IO_Event_Selector_URing_close(VALUE self) {
 	close_internal(selector);
 	
 	return Qnil;
+}
+
+VALUE IO_Event_Selector_URing_closed_p(VALUE self) {
+	struct IO_Event_Selector_URing *selector = NULL;
+	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, selector);
+	
+	return selector->ring.ring_fd < 0 || selector->owner != getpid() ? Qtrue : Qfalse;
 }
 
 VALUE IO_Event_Selector_URing_transfer(VALUE self)
@@ -1378,6 +1396,7 @@ void Init_IO_Event_Selector_URing(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_URing, "select", IO_Event_Selector_URing_select, 1);
 	rb_define_method(IO_Event_Selector_URing, "wakeup", IO_Event_Selector_URing_wakeup, 0);
 	rb_define_method(IO_Event_Selector_URing, "close", IO_Event_Selector_URing_close, 0);
+	rb_define_method(IO_Event_Selector_URing, "closed?", IO_Event_Selector_URing_closed_p, 0);
 	
 	rb_define_method(IO_Event_Selector_URing, "io_wait", IO_Event_Selector_URing_io_wait, 3);
 	

--- a/lib/io/event/debug/selector.rb
+++ b/lib/io/event/debug/selector.rb
@@ -111,6 +111,11 @@ module IO::Event
 				@log&.flush
 			end
 			
+			# @returns [Boolean] Whether the wrapped selector is closed.
+			def closed?
+				@selector.nil? || @selector.closed?
+			end
+			
 			# Transfer from the calling fiber to the selector.
 			def transfer
 				log("Transfering to event loop")

--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -13,6 +13,7 @@ module IO::Event
 			# Initialize the selector with the given event loop fiber.
 			def initialize(loop)
 				@loop = loop
+				@owner = Process.pid
 				
 				@waiting = Hash.new.compare_by_identity
 				
@@ -50,6 +51,11 @@ module IO::Event
 				
 				@loop = nil
 				@waiting = nil
+			end
+			
+			# @returns [Boolean] Whether the selector is closed or belongs to a different process.
+			def closed?
+				@loop.nil? || @owner != Process.pid
 			end
 			
 			# An optional reference to a fiber which can be cleared before it is resumed.

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Report inherited selector objects as closed after fork, and avoid closing descriptors they no longer own.
+
 ## v1.16.4
 
   - Correctly implement `Interrupt#signal` so that it is robust enough to be called by `Scheduler#unblock`.

--- a/test/io/event/debug/selector.rb
+++ b/test/io/event/debug/selector.rb
@@ -32,6 +32,10 @@ class FakeSelector
 		@closed = true
 	end
 	
+	def closed?
+		@closed
+	end
+	
 	def transfer
 		:calls_transfer
 	end
@@ -136,6 +140,7 @@ describe IO::Event::Debug::Selector do
 		expect(selector.push(fiber)).to be == :calls_push
 		expect(selector.raise(fiber, "Boom")).to be == :calls_raise
 		expect(selector.ready?).to be == false
+		expect(selector.closed?).to be == false
 		expect(selector.blocking_operation_wait(:operation)).to be == :calls_blocking_operation_wait
 		expect(selector.process_wait(123, 0)).to be == :calls_process_wait
 		expect(selector.io_wait(fiber, input, IO::READABLE)).to be == :calls_io_wait

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -788,6 +788,31 @@ IO::Event::Selector.constants.each do |name|
 				
 				selectors.each(&:close)
 			end
+			
+			it "is closed in a forked child" do
+				skip_unless_method_defined(:fork, Process.singleton_class)
+				
+				begin
+					inherited_selector = subject.new(loop)
+					waited = false
+					
+					expect(inherited_selector).not.to be(:closed?)
+					
+					pid = Process.fork do
+						exit!(inherited_selector.closed? ? 0 : 1)
+					end
+					
+					Process.wait(pid)
+					waited = true
+					expect($?).to be(:success?)
+				ensure
+					inherited_selector&.close
+					
+					if pid and !waited
+						Process.wait(pid)
+					end
+				end
+			end
 		end
 		
 		with "an instance" do


### PR DESCRIPTION
## Summary

- Track the owning process id for native selector descriptors.
- Add `closed?` to selectors; inherited selector objects report closed after fork.
- Skip closing selector-owned descriptors from copied selector objects after fork.
- Add a regression test that forks after creating a selector and confirms the inherited selector is closed in the child.
- Add an unreleased note.

## Context

A forked child can inherit Ruby selector objects whose native descriptor number no longer refers to the same kernel resource in the child. On macOS, kqueue descriptors are not inherited across fork, so a child-created selector can reuse the same descriptor number. If the inherited selector object is later closed or finalized, it can close a child-owned selector descriptor and cause `Errno::EBADF` from `kevent`.

## Validation

- `bundle exec bake build`
- `bundle exec sus test/io/event/selector.rb test/io/event/debug/selector.rb`
- `bundle exec sus`
- `bundle exec rubocop -A lib/io/event/debug/selector.rb lib/io/event/selector/select.rb test/io/event/selector.rb test/io/event/debug/selector.rb`
