### PR TITLE
Avoid blocking selectors with pending interrupts

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -1016,15 +1016,19 @@ VALUE IO_Event_Selector_EPoll_select(VALUE self, VALUE duration) {
 		arguments.timeout = make_timeout(duration, &arguments.storage);
 		
 		if (!timeout_nonblocking(arguments.timeout)) {
-			struct timespec start_time;
-			IO_Event_Time_current(&start_time);
-			
-			// Wait for events to occur:
-			select_internal_without_gvl(&arguments);
-			
-			struct timespec end_time;
-			IO_Event_Time_current(&end_time);
-			IO_Event_Time_elapsed(&start_time, &end_time, &selector->idle_duration);
+			if (IO_Event_Selector_pending_interrupt()) {
+				arguments.count = 0;
+			} else {
+				struct timespec start_time;
+				IO_Event_Time_current(&start_time);
+				
+				// Wait for events to occur:
+				select_internal_without_gvl(&arguments);
+				
+				struct timespec end_time;
+				IO_Event_Time_current(&end_time);
+				IO_Event_Time_elapsed(&start_time, &end_time, &selector->idle_duration);
+			}
 		}
 	}
 	

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -1004,15 +1004,19 @@ VALUE IO_Event_Selector_KQueue_select(VALUE self, VALUE duration) {
 		if (!timeout_nonblocking(arguments.timeout)) {
 			arguments.count = KQUEUE_MAX_EVENTS;
 			
-			struct timespec start_time;
-			IO_Event_Time_current(&start_time);
-			
-			if (DEBUG) fprintf(stderr, "IO_Event_Selector_KQueue_select timeout=" IO_EVENT_TIME_PRINTF_TIMESPEC "\n", IO_EVENT_TIME_PRINTF_TIMESPEC_ARGUMENTS(arguments.storage));
-			select_internal_without_gvl(&arguments);
-			
-			struct timespec end_time;
-			IO_Event_Time_current(&end_time);
-			IO_Event_Time_elapsed(&start_time, &end_time, &selector->idle_duration);
+			if (IO_Event_Selector_pending_interrupt()) {
+				arguments.count = 0;
+			} else {
+				struct timespec start_time;
+				IO_Event_Time_current(&start_time);
+				
+				if (DEBUG) fprintf(stderr, "IO_Event_Selector_KQueue_select timeout=" IO_EVENT_TIME_PRINTF_TIMESPEC "\n", IO_EVENT_TIME_PRINTF_TIMESPEC_ARGUMENTS(arguments.storage));
+				select_internal_without_gvl(&arguments);
+				
+				struct timespec end_time;
+				IO_Event_Time_current(&end_time);
+				IO_Event_Time_elapsed(&start_time, &end_time, &selector->idle_duration);
+			}
 		}
 	}
 	

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -40,6 +40,16 @@ static inline int IO_Event_try_again(int error) {
 	return error == EAGAIN || error == EWOULDBLOCK;
 }
 
+static inline int IO_Event_Selector_pending_interrupt(void) {
+	static ID pending_interrupt = 0;
+	
+	if (!pending_interrupt) {
+		pending_interrupt = rb_intern("pending_interrupt?");
+	}
+	
+	return RTEST(rb_funcall(rb_cThread, pending_interrupt, 0));
+}
+
 #ifdef HAVE_RB_IO_DESCRIPTOR
 #define IO_Event_Selector_io_descriptor(io) rb_io_descriptor(io)
 #else

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -1282,19 +1282,23 @@ VALUE IO_Event_Selector_URing_select(VALUE self, VALUE duration) {
 		arguments.timeout = make_timeout(duration, &arguments.storage);
 		
 		if (!selector->backend.ready && !timeout_nonblocking(arguments.timeout)) {
-			struct timespec start_time;
-			IO_Event_Time_current(&start_time);
-			
-			// This is a blocking operation, we wait for events:
-			result = select_internal_without_gvl(&arguments);
-			
-			struct timespec end_time;
-			IO_Event_Time_current(&end_time);
-			IO_Event_Time_elapsed(&start_time, &end_time, &selector->idle_duration);
-			
-			// After waiting/flushing the SQ, check if there are any completions:
-			if (result > 0) {
-				result = select_process_completions(selector);
+			if (IO_Event_Selector_pending_interrupt()) {
+				result = 0;
+			} else {
+				struct timespec start_time;
+				IO_Event_Time_current(&start_time);
+				
+				// This is a blocking operation, we wait for events:
+				result = select_internal_without_gvl(&arguments);
+				
+				struct timespec end_time;
+				IO_Event_Time_current(&end_time);
+				IO_Event_Time_elapsed(&start_time, &end_time, &selector->idle_duration);
+				
+				// After waiting/flushing the SQ, check if there are any completions:
+				if (result > 0) {
+					result = select_process_completions(selector);
+				}
 			}
 		}
 	}

--- a/test/io/event/interrupt.rb
+++ b/test/io/event/interrupt.rb
@@ -41,6 +41,8 @@ describe IO::Event.const_get(:Interrupt) do
 	with "test scheduler" do
 		it "can be used to wake up a fiber blocked in `Thread#join`" do
 			skip_unless_method_defined(:fork, Process.singleton_class)
+			skip "Process.fork is not available on JRuby." if RUBY_ENGINE == "jruby"
+			skip "Fiber.set_scheduler is not available." unless Fiber.respond_to?(:set_scheduler)
 			
 			10.times do
 				r, w = IO.pipe

--- a/test/io/event/selector/interruptable.rb
+++ b/test/io/event/selector/interruptable.rb
@@ -29,6 +29,35 @@ Interruptable = Sus::Shared("interruptable") do
 		expect(result).to be == 0
 	end
 	
+	it "does not block when interrupt is already pending" do
+		selector = subject.new(Fiber.current)
+		timeout = false
+		
+		thread = Thread.new do
+			Thread.current.report_on_exception = false
+			
+			Thread.handle_interrupt(::SignalException => :never) do
+				Thread.current.raise(::Interrupt)
+				selector.select(nil)
+			end
+		end
+		
+		watchdog = Thread.new do
+			sleep(0.1)
+			
+			if thread.alive?
+				timeout = true
+				selector.wakeup
+			end
+		end
+		
+		expect{thread.join}.to raise_exception(::Interrupt)
+		expect(timeout).to be == false
+	ensure
+		watchdog&.kill
+		thread&.kill
+	end
+	
 	with "pipe" do
 		let(:pipe) {IO.pipe}
 		let(:input) {pipe.first}


### PR DESCRIPTION
## Summary

- add a regression test for selectors entering `select(nil)` while `Interrupt` is already pending but masked by `Thread.handle_interrupt`
- check for pending Ruby thread interrupts before native selectors enter their blocking backend wait
- return without blocking, matching the existing `EINTR`/zero-ready behavior

## Motivation

This reproduces a lost-wakeup path observed through async-container: `SIGINT` can be converted to a deferred `Interrupt` while Async is between its pending-interrupt check and the selector wait. If the native selector then enters an indefinite wait, the scheduler can sleep forever even though an interrupt is pending.

## Testing

- `bundle exec sus test/io/event/selector.rb test/io/event/selector/interruptable.rb`
- `bundle exec bake test`