### PR TITLE
Avoid blocking selectors with pending interrupts

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -830,8 +830,26 @@ struct timespec * make_timeout(VALUE duration, struct timespec * storage) {
 }
 
 static
-int timeout_nonblocking(struct timespec * timespec) {
+int timeout_is_nonblocking(struct timespec * timespec) {
 	return timespec && timespec->tv_sec == 0 && timespec->tv_nsec == 0;
+}
+
+// Return true when it is safe and useful to enter the blocking selector wait.
+static
+int select_blocking_allowed(struct timespec * timespec) {
+	// A `0` timeout is already a poll. The selector has already performed the immediate poll previously, so there is no useful blocking wait to enter here.
+	if (timeout_is_nonblocking(timespec)) {
+		return 0;
+	}
+	
+#ifndef RB_NOGVL_PENDING_INTERRUPT_FAIL
+	// On Rubies without `RB_NOGVL_PENDING_INTERRUPT_FAIL`, `rb_thread_call_without_gvl2` can enter an indefinite native wait even if a masked interrupt is already pending for this thread. This is the last safe point to avoid that wait: we still hold the GVL, so the pending interrupt queue cannot change concurrently before we decide whether to enter the blocking path.
+	if (IO_Event_Selector_pending_interrupt()) {
+		return 0;
+	}
+#endif
+	
+	return 1;
 }
 
 struct select_arguments {
@@ -852,7 +870,7 @@ static int make_timeout_ms(struct timespec * timeout) {
 		return -1;
 	}
 	
-	if (timeout_nonblocking(timeout)) {
+	if (timeout_is_nonblocking(timeout)) {
 		return 0;
 	}
 	
@@ -894,12 +912,18 @@ void * select_internal(void *_arguments) {
 
 static
 int select_internal_without_gvl(struct select_arguments *arguments) {
+	arguments->result = -1;
 	arguments->selector->blocked = 1;
-	rb_thread_call_without_gvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
+#ifdef RB_NOGVL_PENDING_INTERRUPT_FAIL
+	rb_nogvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0, RB_NOGVL_INTR_FAIL | RB_NOGVL_PENDING_INTERRUPT_FAIL);
+#else
+	rb_thread_call_without_gvl2(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
+#endif
 	arguments->selector->blocked = 0;
 	
 	if (arguments->result == -1) {
-		if (errno != EINTR) {
+		// If Ruby skips the native callback, the result sentinel can remain `-1`; `errno` may be `0` or `EINTR` depending on the Ruby implementation. Both cases mean the blocking wait did not produce any events.
+		if (errno != EINTR && errno != 0) {
 			rb_sys_fail("select_internal_without_gvl:epoll_wait");
 		} else {
 			return 0;
@@ -1035,7 +1059,7 @@ VALUE IO_Event_Selector_EPoll_select(VALUE self, VALUE duration) {
 	if (!ready && !result && !selector->backend.ready) {
 		arguments.timeout = make_timeout(duration, &arguments.storage);
 		
-		if (!timeout_nonblocking(arguments.timeout)) {
+		if (select_blocking_allowed(arguments.timeout)) {
 			struct timespec start_time;
 			IO_Event_Time_current(&start_time);
 			

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -838,9 +838,22 @@ struct timespec * make_timeout(VALUE duration, struct timespec * storage) {
 	return storage;
 }
 
+// Return true when it is safe and useful to enter the blocking selector wait.
 static
-int timeout_nonblocking(struct timespec * timespec) {
-	return timespec && timespec->tv_sec == 0 && timespec->tv_nsec == 0;
+int select_blocking_allowed(struct timespec * timespec) {
+	// A `0` timeout is already a poll. The selector has already performed the immediate poll previously, so there is no useful blocking wait to enter here.
+	if (timespec && timespec->tv_sec == 0 && timespec->tv_nsec == 0) {
+		return 0;
+	}
+	
+#ifndef RB_NOGVL_PENDING_INTERRUPT_FAIL
+	// On Rubies without `RB_NOGVL_PENDING_INTERRUPT_FAIL`, `rb_thread_call_without_gvl2` can enter an indefinite native wait even if a masked interrupt is already pending for this thread. This is the last safe point to avoid that wait: we still hold the GVL, so the pending interrupt queue cannot change concurrently before we decide whether to enter the blocking path.
+	if (IO_Event_Selector_pending_interrupt()) {
+		return 0;
+	}
+#endif
+	
+	return 1;
 }
 
 struct select_arguments {
@@ -867,13 +880,19 @@ void * select_internal(void *_arguments) {
 
 static
 int select_internal_without_gvl(struct select_arguments *arguments) {
+	arguments->result = -1;
 	arguments->selector->blocked = 1;
 	
-	rb_thread_call_without_gvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
+#ifdef RB_NOGVL_PENDING_INTERRUPT_FAIL
+	rb_nogvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0, RB_NOGVL_INTR_FAIL | RB_NOGVL_PENDING_INTERRUPT_FAIL);
+#else
+	rb_thread_call_without_gvl2(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
+#endif
 	arguments->selector->blocked = 0;
 	
 	if (arguments->result == -1) {
-		if (errno != EINTR) {
+		// If Ruby skips the native callback, the result sentinel can remain `-1`; `errno` may be `0` or `EINTR` depending on the Ruby implementation. Both cases mean the blocking wait did not produce any events.
+		if (errno != EINTR && errno != 0) {
 			rb_sys_fail("select_internal_without_gvl:kevent");
 		} else {
 			return 0;
@@ -1021,7 +1040,7 @@ VALUE IO_Event_Selector_KQueue_select(VALUE self, VALUE duration) {
 	if (!ready && !result && !selector->backend.ready) {
 		arguments.timeout = make_timeout(duration, &arguments.storage);
 		
-		if (!timeout_nonblocking(arguments.timeout)) {
+		if (select_blocking_allowed(arguments.timeout)) {
 			struct timespec start_time;
 			IO_Event_Time_current(&start_time);
 			

--- a/ext/io/event/selector/selector.c
+++ b/ext/io/event/selector/selector.c
@@ -8,6 +8,8 @@
 
 static const int DEBUG = 0;
 
+ID IO_Event_Selector_pending_interrupt_p_id;
+
 #ifndef HAVE_RB_IO_DESCRIPTOR
 static ID id_fileno;
 
@@ -79,6 +81,8 @@ static VALUE IO_Event_Selector_nonblock(VALUE class, VALUE io)
 }
 
 void Init_IO_Event_Selector(VALUE IO_Event_Selector) {
+	IO_Event_Selector_pending_interrupt_p_id = rb_intern("pending_interrupt?");
+	
 #ifndef HAVE_RB_IO_DESCRIPTOR
 	id_fileno = rb_intern("fileno");
 #endif

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -40,6 +40,12 @@ static inline int IO_Event_try_again(int error) {
 	return error == EAGAIN || error == EWOULDBLOCK;
 }
 
+extern ID IO_Event_Selector_pending_interrupt_p_id;
+
+static inline int IO_Event_Selector_pending_interrupt(void) {
+	return RTEST(rb_funcall(rb_cThread, IO_Event_Selector_pending_interrupt_p_id, 0));
+}
+
 #ifdef HAVE_RB_IO_DESCRIPTOR
 #define IO_Event_Selector_io_descriptor(io) rb_io_descriptor(io)
 #else

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -1130,9 +1130,22 @@ struct __kernel_timespec * make_timeout(VALUE duration, struct __kernel_timespec
 	return storage;
 }
 
+// Return true when it is safe and useful to enter the blocking selector wait.
 static
-int timeout_nonblocking(struct __kernel_timespec *timespec) {
-	return timespec && timespec->tv_sec == 0 && timespec->tv_nsec == 0;
+int select_blocking_allowed(struct __kernel_timespec *timespec) {
+	// A `0` timeout is already a poll. The selector has already performed the immediate poll previously, so there is no useful blocking wait to enter here.
+	if (timespec && timespec->tv_sec == 0 && timespec->tv_nsec == 0) {
+		return 0;
+	}
+	
+#ifndef RB_NOGVL_PENDING_INTERRUPT_FAIL
+	// On Rubies without `RB_NOGVL_PENDING_INTERRUPT_FAIL`, `rb_thread_call_without_gvl2` can enter an indefinite native wait even if a masked interrupt is already pending for this thread. This is the last safe point to avoid that wait: we still hold the GVL, so the pending interrupt queue cannot change concurrently before we decide whether to enter the blocking path.
+	if (IO_Event_Selector_pending_interrupt()) {
+		return 0;
+	}
+#endif
+	
+	return 1;
 }
 
 struct select_arguments {
@@ -1171,8 +1184,13 @@ int select_internal_without_gvl(struct select_arguments *arguments) {
 	
 	io_uring_submit_flush(selector);
 	
+	arguments->result = -EINTR;
 	selector->blocked = 1;
-	rb_thread_call_without_gvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
+#ifdef RB_NOGVL_PENDING_INTERRUPT_FAIL
+	rb_nogvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0, RB_NOGVL_INTR_FAIL | RB_NOGVL_PENDING_INTERRUPT_FAIL);
+#else
+	rb_thread_call_without_gvl2(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
+#endif
 	selector->blocked = 0;
 	
 	if (arguments->result == -ETIME) {
@@ -1300,7 +1318,7 @@ VALUE IO_Event_Selector_URing_select(VALUE self, VALUE duration) {
 		
 		arguments.timeout = make_timeout(duration, &arguments.storage);
 		
-		if (!selector->backend.ready && !timeout_nonblocking(arguments.timeout)) {
+		if (!selector->backend.ready && select_blocking_allowed(arguments.timeout)) {
 			struct timespec start_time;
 			IO_Event_Time_current(&start_time);
 			

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - **Fixed**: Avoid entering a blocking native selector wait when an interrupt is already pending for the current thread.
+
 ## v1.17.0
 
   - Report inherited selector objects as closed after fork, and avoid closing descriptors they no longer own.

--- a/test/io/event/selector/interruptable.rb
+++ b/test/io/event/selector/interruptable.rb
@@ -8,6 +8,35 @@ require "io/event/selector"
 require "socket"
 
 Interruptable = Sus::Shared("interruptable") do
+	it "does not block with pending interrupts" do
+		selector = subject.new(Fiber.current)
+		woken = false
+		
+		watchdog = Thread.new do
+			sleep(0.1)
+			woken = true
+			selector.wakeup
+		end
+		
+		result = nil
+		
+		begin
+			begin
+				Thread.handle_interrupt(::SignalException => :never) do
+					Thread.current.raise(::Interrupt)
+					result = selector.select(nil)
+				end
+			rescue ::Interrupt
+			end
+		ensure
+			watchdog.kill
+			watchdog.join
+		end
+		
+		expect(result).to be == 0
+		expect(woken).to be == false
+	end
+	
 	it "can interrupt sleeping selector" do
 		result = nil
 		


### PR DESCRIPTION
This is an alternative to #196 that uses `rb_thread_call_without_gvl2`/`rb_nogvl` for blocking native selector waits.

While testing this approach, `rb_thread_call_without_gvl2` alone was not sufficient on current CRuby: a masked pending interrupt can leave `Thread.pending_interrupt?` true after the VM interrupt bit has already been checked/cleared, so `without_gvl2` can still enter the blocking syscall.

This PR combines both approaches:

* on Rubies with `RB_NOGVL_PENDING_INTERRUPT_FAIL`, use `rb_nogvl(..., RB_NOGVL_INTR_FAIL | RB_NOGVL_PENDING_INTERRUPT_FAIL)` so CRuby checks the pending interrupt queue at the GVL/blocking-region boundary;
* on older Rubies, fold the fallback `Thread.pending_interrupt?` check into the selector's `select_blocking_allowed` decision, along with zero-timeout handling, so pending interrupts avoid entering the blocking native wait;
* preload the `pending_interrupt?` method ID during selector initialization, so the fallback helper does not lazily intern from the selector path;
* initialize the selector result to an interrupt sentinel before entering the without-GVL wait, so if Ruby skips the native callback due to a pending interrupt, the selector normalizes that path like `EINTR`/zero events.

The regression test raises an interrupt under `Thread.handle_interrupt(SignalException => :never)` before `select(nil)`. A watchdog wakes the selector only to avoid hanging the suite; if it fires, the test fails.

Note: despite the helper name, `select_internal_without_gvl` itself runs with the GVL. Only the callback passed to `rb_thread_call_without_gvl2`/`rb_nogvl` runs without it, so existing `rb_sys_fail`/`rb_syserr_fail` calls after that function returns are still made with the GVL held.

Tests:

```sh
PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH bundle exec bake build
PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH RUBYLIB=.:lib bundle exec sus test/io/event/selector.rb test/io/event/selector/interruptable.rb
PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH RUBYLIB=.:lib bundle exec sus
```
