### PR TITLE
Clarify selector result handling

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -838,6 +838,7 @@ struct select_arguments {
 	struct IO_Event_Selector_EPoll *selector;
 	
 	int count;
+	int result;
 	struct epoll_event events[EPOLL_MAX_EVENTS];
 	
 	struct timespec * timeout;
@@ -872,13 +873,13 @@ void * select_internal(void *_arguments) {
 	struct select_arguments * arguments = (struct select_arguments *)_arguments;
 	
 #if defined(HAVE_EPOLL_PWAIT2)
-	arguments->count = epoll_pwait2(arguments->selector->descriptor, arguments->events, EPOLL_MAX_EVENTS, arguments->timeout, NULL);
+	arguments->result = epoll_pwait2(arguments->selector->descriptor, arguments->events, arguments->count, arguments->timeout, NULL);
 	
 	// Comment out the above line and enable the below lines to test ENOSYS code path.
-	// arguments->count = -1;
+	// arguments->result = -1;
 	// errno = ENOSYS;
 	
-	if (!enosys_error(arguments->count)) {
+	if (!enosys_error(arguments->result)) {
 		return NULL;
 	}
 	else {
@@ -886,37 +887,41 @@ void * select_internal(void *_arguments) {
 	}
 #endif
 	
-	arguments->count = epoll_wait(arguments->selector->descriptor, arguments->events, EPOLL_MAX_EVENTS, make_timeout_ms(arguments->timeout));
+	arguments->result = epoll_wait(arguments->selector->descriptor, arguments->events, arguments->count, make_timeout_ms(arguments->timeout));
 	
 	return NULL;
 }
 
 static
-void select_internal_without_gvl(struct select_arguments *arguments) {
+int select_internal_without_gvl(struct select_arguments *arguments) {
 	arguments->selector->blocked = 1;
 	rb_thread_call_without_gvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
 	arguments->selector->blocked = 0;
 	
-	if (arguments->count == -1) {
+	if (arguments->result == -1) {
 		if (errno != EINTR) {
 			rb_sys_fail("select_internal_without_gvl:epoll_wait");
 		} else {
-			arguments->count = 0;
+			return 0;
 		}
 	}
+	
+	return arguments->result;
 }
 
 static
-void select_internal_with_gvl(struct select_arguments *arguments) {
+int select_internal_with_gvl(struct select_arguments *arguments) {
 	select_internal((void *)arguments);
 	
-	if (arguments->count == -1) {
+	if (arguments->result == -1) {
 		if (errno != EINTR) {
 			rb_sys_fail("select_internal_with_gvl:epoll_wait");
 		} else {
-			arguments->count = 0;
+			return 0;
 		}
 	}
+	
+	return arguments->result;
 }
 
 static
@@ -972,7 +977,7 @@ VALUE select_handle_events(VALUE _arguments)
 	struct select_arguments *arguments = (struct select_arguments *)_arguments;
 	struct IO_Event_Selector_EPoll *selector = arguments->selector;
 	
-	for (int i = 0; i < arguments->count; i += 1) {
+	for (int i = 0; i < arguments->result; i += 1) {
 		const struct epoll_event *event = &arguments->events[i];
 		if (DEBUG) fprintf(stderr, "-> fd=%d events=%d\n", event->data.fd, event->events);
 		
@@ -983,7 +988,7 @@ VALUE select_handle_events(VALUE _arguments)
 		}
 	}
 	
-	return INT2NUM(arguments->count);
+	return INT2NUM(arguments->result);
 }
 
 static
@@ -1008,6 +1013,8 @@ VALUE IO_Event_Selector_EPoll_select(VALUE self, VALUE duration) {
 	
 	struct select_arguments arguments = {
 		.selector = selector,
+		.count = EPOLL_MAX_EVENTS,
+		.result = 0,
 		.storage = {
 			.tv_sec = 0,
 			.tv_nsec = 0
@@ -1018,14 +1025,14 @@ VALUE IO_Event_Selector_EPoll_select(VALUE self, VALUE duration) {
 	arguments.timeout = &arguments.storage;
 
 	// Process any currently pending events:
-	select_internal_with_gvl(&arguments);
+	int result = select_internal_with_gvl(&arguments);
 	
 	// If we:
 	// 1. Didn't process any ready fibers, and
 	// 2. Didn't process any events from non-blocking select (above), and
 	// 3. There are no items in the ready list,
 	// then we can perform a blocking select.
-	if (!ready && !arguments.count && !selector->backend.ready) {
+	if (!ready && !result && !selector->backend.ready) {
 		arguments.timeout = make_timeout(duration, &arguments.storage);
 		
 		if (!timeout_nonblocking(arguments.timeout)) {
@@ -1033,7 +1040,7 @@ VALUE IO_Event_Selector_EPoll_select(VALUE self, VALUE duration) {
 			IO_Event_Time_current(&start_time);
 			
 			// Wait for events to occur:
-			select_internal_without_gvl(&arguments);
+			result = select_internal_without_gvl(&arguments);
 			
 			struct timespec end_time;
 			IO_Event_Time_current(&end_time);
@@ -1041,7 +1048,7 @@ VALUE IO_Event_Selector_EPoll_select(VALUE self, VALUE duration) {
 		}
 	}
 	
-	if (arguments.count) {
+	if (result) {
 		return rb_ensure(select_handle_events, (VALUE)&arguments, select_handle_events_ensure, (VALUE)&arguments);
 	} else {
 		return RB_INT2NUM(0);

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -847,6 +847,7 @@ struct select_arguments {
 	struct IO_Event_Selector_KQueue *selector;
 	
 	int count;
+	int result;
 	struct kevent events[KQUEUE_MAX_EVENTS];
 	
 	struct timespec storage;
@@ -859,38 +860,42 @@ static
 void * select_internal(void *_arguments) {
 	struct select_arguments * arguments = (struct select_arguments *)_arguments;
 	
-	arguments->count = kevent(arguments->selector->descriptor, NULL, 0, arguments->events, arguments->count, arguments->timeout);
+	arguments->result = kevent(arguments->selector->descriptor, NULL, 0, arguments->events, arguments->count, arguments->timeout);
 	
 	return NULL;
 }
 
 static
-void select_internal_without_gvl(struct select_arguments *arguments) {
+int select_internal_without_gvl(struct select_arguments *arguments) {
 	arguments->selector->blocked = 1;
 	
 	rb_thread_call_without_gvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
 	arguments->selector->blocked = 0;
 	
-	if (arguments->count == -1) {
+	if (arguments->result == -1) {
 		if (errno != EINTR) {
 			rb_sys_fail("select_internal_without_gvl:kevent");
 		} else {
-			arguments->count = 0;
+			return 0;
 		}
 	}
+	
+	return arguments->result;
 }
 
 static
-void select_internal_with_gvl(struct select_arguments *arguments) {
+int select_internal_with_gvl(struct select_arguments *arguments) {
 	select_internal((void *)arguments);
 	
-	if (arguments->count == -1) {
+	if (arguments->result == -1) {
 		if (errno != EINTR) {
 			rb_sys_fail("select_internal_with_gvl:kevent");
 		} else {
-			arguments->count = 0;
+			return 0;
 		}
 	}
+	
+	return arguments->result;
 }
 
 static
@@ -944,14 +949,14 @@ VALUE select_handle_events(VALUE _arguments)
 	struct select_arguments *arguments = (struct select_arguments *)_arguments;
 	struct IO_Event_Selector_KQueue *selector = arguments->selector;
 	
-	for (int i = 0; i < arguments->count; i += 1) {
+	for (int i = 0; i < arguments->result; i += 1) {
 		if (arguments->events[i].udata) {
 			struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = arguments->events[i].udata;
 			kqueue_descriptor->ready_events |= events_from_kevent_filter(arguments->events[i].filter);
 		}
 	}
 	
-	for (int i = 0; i < arguments->count; i += 1) {
+	for (int i = 0; i < arguments->result; i += 1) {
 		if (arguments->events[i].udata) {
 			struct IO_Event_Selector_KQueue_Descriptor *kqueue_descriptor = arguments->events[i].udata;
 			IO_Event_Selector_KQueue_handle(selector, arguments->events[i].ident, kqueue_descriptor, &arguments->saved);
@@ -962,7 +967,7 @@ VALUE select_handle_events(VALUE _arguments)
 		}
 	}
 	
-	return RB_INT2NUM(arguments->count);
+	return RB_INT2NUM(arguments->result);
 }
 
 static
@@ -987,6 +992,7 @@ VALUE IO_Event_Selector_KQueue_select(VALUE self, VALUE duration) {
 	struct select_arguments arguments = {
 		.selector = selector,
 		.count = KQUEUE_MAX_EVENTS,
+		.result = 0,
 		.storage = {
 			.tv_sec = 0,
 			.tv_nsec = 0
@@ -997,14 +1003,14 @@ VALUE IO_Event_Selector_KQueue_select(VALUE self, VALUE duration) {
 	arguments.timeout = &arguments.storage;
 	
 	// We break this implementation into two parts.
-	// (1) count = kevent(..., timeout = 0)
-	// (2) without gvl: kevent(..., timeout = 0) if count == 0 and timeout != 0
+	// (1) result = kevent(..., timeout = 0)
+	// (2) without gvl: kevent(..., timeout = 0) if result == 0 and timeout != 0
 	// This allows us to avoid releasing and reacquiring the GVL.
 	// Non-comprehensive testing shows this gives a 1.5x speedup.
 	
 	// First do the syscall with no timeout to get any immediately available events:
 	if (DEBUG) fprintf(stderr, "\r\nselect_internal_with_gvl timeout=" IO_EVENT_TIME_PRINTF_TIMESPEC "\r\n", IO_EVENT_TIME_PRINTF_TIMESPEC_ARGUMENTS(arguments.storage));
-	select_internal_with_gvl(&arguments);
+	int result = select_internal_with_gvl(&arguments);
 	if (DEBUG) fprintf(stderr, "\r\nselect_internal_with_gvl done\r\n");
 	
 	// If we:
@@ -1012,17 +1018,15 @@ VALUE IO_Event_Selector_KQueue_select(VALUE self, VALUE duration) {
 	// 2. Didn't process any events from non-blocking select (above), and
 	// 3. There are no items in the ready list,
 	// then we can perform a blocking select.
-	if (!ready && !arguments.count && !selector->backend.ready) {
+	if (!ready && !result && !selector->backend.ready) {
 		arguments.timeout = make_timeout(duration, &arguments.storage);
 		
 		if (!timeout_nonblocking(arguments.timeout)) {
-			arguments.count = KQUEUE_MAX_EVENTS;
-			
 			struct timespec start_time;
 			IO_Event_Time_current(&start_time);
 			
 			if (DEBUG) fprintf(stderr, "IO_Event_Selector_KQueue_select timeout=" IO_EVENT_TIME_PRINTF_TIMESPEC "\n", IO_EVENT_TIME_PRINTF_TIMESPEC_ARGUMENTS(arguments.storage));
-			select_internal_without_gvl(&arguments);
+			result = select_internal_without_gvl(&arguments);
 			
 			struct timespec end_time;
 			IO_Event_Time_current(&end_time);
@@ -1030,7 +1034,7 @@ VALUE IO_Event_Selector_KQueue_select(VALUE self, VALUE duration) {
 		}
 	}
 	
-	if (arguments.count) {
+	if (result) {
 		return rb_ensure(select_handle_events, (VALUE)&arguments, select_handle_events_ensure, (VALUE)&arguments);
 	} else {
 		return RB_INT2NUM(0);

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -1176,17 +1176,17 @@ int select_internal_without_gvl(struct select_arguments *arguments) {
 	selector->blocked = 0;
 	
 	if (arguments->result == -ETIME) {
-		arguments->result = 0;
+		return 0;
 	} else if (arguments->result == -EINTR) {
-		arguments->result = 0;
+		return 0;
 	} else if (arguments->result < 0) {
 		rb_syserr_fail(-arguments->result, "select_internal_without_gvl:io_uring_wait_cqe_timeout");
 	} else {
 		// At least 1 event is waiting:
-		arguments->result = 1;
+		return 1;
 	}
 	
-	return arguments->result;
+	return 0;
 }
 
 static inline
@@ -1283,17 +1283,18 @@ VALUE IO_Event_Selector_URing_select(VALUE self, VALUE duration) {
 	
 	int ready = IO_Event_Selector_ready_flush(&selector->backend);
 	
-	int result = select_process_completions(selector);
+	int completed = select_process_completions(selector);
 	
 	// If we:
 	// 1. Didn't process any ready fibers, and
 	// 2. Didn't process any events from non-blocking select (above), and
 	// 3. There are no items in the ready list,
 	// then we can perform a blocking select.
-	if (!ready && !result && !selector->backend.ready) {
+	if (!ready && !completed && !selector->backend.ready) {
 		// We might need to wait for events:
 		struct select_arguments arguments = {
 			.selector = selector,
+			.result = 0,
 			.timeout = NULL,
 		};
 		
@@ -1304,7 +1305,7 @@ VALUE IO_Event_Selector_URing_select(VALUE self, VALUE duration) {
 			IO_Event_Time_current(&start_time);
 			
 			// This is a blocking operation, we wait for events:
-			result = select_internal_without_gvl(&arguments);
+			int result = select_internal_without_gvl(&arguments);
 			
 			struct timespec end_time;
 			IO_Event_Time_current(&end_time);
@@ -1312,12 +1313,12 @@ VALUE IO_Event_Selector_URing_select(VALUE self, VALUE duration) {
 			
 			// After waiting/flushing the SQ, check if there are any completions:
 			if (result > 0) {
-				result = select_process_completions(selector);
+				completed = select_process_completions(selector);
 			}
 		}
 	}
 	
-	return RB_INT2NUM(result);
+	return RB_INT2NUM(completed);
 }
 
 VALUE IO_Event_Selector_URing_wakeup(VALUE self) {


### PR DESCRIPTION
This separates selector event capacity from native call results in the C selector backends.

- `kqueue` and `epoll` now keep `arguments->count` as the event buffer capacity and store native selector return values in `arguments->result`.
- Event handling loops use `arguments->result`, while native calls use `arguments->count` as the buffer size.
- `io_uring` keeps `arguments->result` as the raw wait call result and uses a local `completed` value for processed completions.

This is intended as a small readability cleanup ahead of the interrupt handling work, without changing behavior.