### PR TITLE
Move selector wait errors out of no-GVL helpers

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -898,14 +898,6 @@ int select_internal_without_gvl(struct select_arguments *arguments) {
 	rb_thread_call_without_gvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
 	arguments->selector->blocked = 0;
 	
-	if (arguments->result == -1) {
-		if (errno != EINTR) {
-			rb_sys_fail("select_internal_without_gvl:epoll_wait");
-		} else {
-			return 0;
-		}
-	}
-	
 	return arguments->result;
 }
 
@@ -1045,6 +1037,14 @@ VALUE IO_Event_Selector_EPoll_select(VALUE self, VALUE duration) {
 			struct timespec end_time;
 			IO_Event_Time_current(&end_time);
 			IO_Event_Time_elapsed(&start_time, &end_time, &selector->idle_duration);
+			
+			if (result == -1) {
+				if (errno != EINTR) {
+					rb_sys_fail("select_internal_without_gvl:epoll_wait");
+				} else {
+					result = 0;
+				}
+			}
 		}
 	}
 	

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -872,14 +872,6 @@ int select_internal_without_gvl(struct select_arguments *arguments) {
 	rb_thread_call_without_gvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
 	arguments->selector->blocked = 0;
 	
-	if (arguments->result == -1) {
-		if (errno != EINTR) {
-			rb_sys_fail("select_internal_without_gvl:kevent");
-		} else {
-			return 0;
-		}
-	}
-	
 	return arguments->result;
 }
 
@@ -1031,6 +1023,14 @@ VALUE IO_Event_Selector_KQueue_select(VALUE self, VALUE duration) {
 			struct timespec end_time;
 			IO_Event_Time_current(&end_time);
 			IO_Event_Time_elapsed(&start_time, &end_time, &selector->idle_duration);
+			
+			if (result == -1) {
+				if (errno != EINTR) {
+					rb_sys_fail("select_internal_without_gvl:kevent");
+				} else {
+					result = 0;
+				}
+			}
 		}
 	}
 	

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -1175,18 +1175,7 @@ int select_internal_without_gvl(struct select_arguments *arguments) {
 	rb_thread_call_without_gvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
 	selector->blocked = 0;
 	
-	if (arguments->result == -ETIME) {
-		return 0;
-	} else if (arguments->result == -EINTR) {
-		return 0;
-	} else if (arguments->result < 0) {
-		rb_syserr_fail(-arguments->result, "select_internal_without_gvl:io_uring_wait_cqe_timeout");
-	} else {
-		// At least 1 event is waiting:
-		return 1;
-	}
-	
-	return 0;
+	return arguments->result;
 }
 
 static inline
@@ -1312,7 +1301,13 @@ VALUE IO_Event_Selector_URing_select(VALUE self, VALUE duration) {
 			IO_Event_Time_elapsed(&start_time, &end_time, &selector->idle_duration);
 			
 			// After waiting/flushing the SQ, check if there are any completions:
-			if (result > 0) {
+			if (result == -ETIME) {
+				// The timeout expired without any completions.
+			} else if (result == -EINTR) {
+				// The wait was interrupted.
+			} else if (result < 0) {
+				rb_syserr_fail(-result, "select_internal_without_gvl:io_uring_wait_cqe_timeout");
+			} else {
 				completed = select_process_completions(selector);
 			}
 		}


### PR DESCRIPTION
This PR moves selector wait error handling out of the `select_internal_without_gvl` helpers and into the outer selector paths.

The no-GVL helpers now only run the native wait and return the raw result. Ruby exception raising via `rb_sys_fail`/`rb_syserr_fail` is handled by the caller after the helper returns.

This keeps the no-GVL helper boundary narrow and avoids mixing native wait execution with Ruby exception handling. It also gives the pending-interrupt work a cleaner base to build on.

Locally verified with:

```sh
PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH RUBYLIB=.:lib bundle exec sus test/io/event/selector.rb test/io/event/selector/interruptable.rb
PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH RUBYLIB=.:lib bundle exec sus
```

Results:

```text
93 passed out of 93 total
249 passed 6 skipped out of 255 total
```