### PR TITLE
Support process_wait for any child / process group (pid <= 0) on all selectors

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -462,7 +462,7 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	IO_Event_Selector_loop_yield(&arguments->selector->backend);
 	
 	if (arguments->waiting->ready) {
-		return IO_Event_Selector_process_status_wait(arguments->pid, arguments->flags);
+		return IO_Event_Selector_process_status_reap(arguments->pid, arguments->flags);
 	} else {
 		return Qfalse;
 	}
@@ -488,6 +488,11 @@ VALUE IO_Event_Selector_EPoll_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 	pid_t pid = NUM2PIDT(_pid);
 	int flags = NUM2INT(_flags);
 	
+	// `pidfd_open` can only refer to a specific process, so waiting for any child or a process group (pid <= 0) is delegated to the threaded fallback:
+	if (pid <= 0) {
+		return IO_Event_Selector_process_wait(pid, flags);
+	}
+	
 	int descriptor = pidfd_open(pid, 0);
 	
 	if (descriptor == -1) {
@@ -497,7 +502,7 @@ VALUE IO_Event_Selector_EPoll_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 	rb_update_max_fd(descriptor);
 	
 	// `pidfd_open` (above) may be edge triggered, so we need to check if the process is already exited, and if so, return immediately, otherwise we will block indefinitely.
-	VALUE status = IO_Event_Selector_process_status_wait(pid, flags);
+	VALUE status = IO_Event_Selector_process_status_reap(pid, flags);
 	if (status != Qnil) {
 		close(descriptor);
 		return status;

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -469,7 +469,7 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	
 	if (arguments->waiting->ready) {
 		process_prewait(arguments->pid);
-		return IO_Event_Selector_process_status_wait(arguments->pid, arguments->flags);
+		return IO_Event_Selector_process_status_reap(arguments->pid, arguments->flags);
 	} else {
 		return Qfalse;
 	}
@@ -493,6 +493,11 @@ VALUE IO_Event_Selector_KQueue_process_wait(VALUE self, VALUE fiber, VALUE _pid,
 	pid_t pid = NUM2PIDT(_pid);
 	int flags = NUM2INT(_flags);
 	
+	// `EVFILT_PROC` can only refer to a specific process, so waiting for any child or a process group (pid <= 0) is delegated to the threaded fallback:
+	if (pid <= 0) {
+		return IO_Event_Selector_process_wait(pid, flags);
+	}
+	
 	struct IO_Event_Selector_KQueue_Waiting waiting = {
 		.list = {.type = &IO_Event_Selector_KQueue_process_wait_list_type},
 		.fiber = fiber,
@@ -514,7 +519,7 @@ VALUE IO_Event_Selector_KQueue_process_wait(VALUE self, VALUE fiber, VALUE _pid,
 		if (errno == ESRCH) {
 			process_prewait(pid);
 			
-			return IO_Event_Selector_process_status_wait(pid, flags);
+			return IO_Event_Selector_process_status_reap(pid, flags);
 		}
 		
 		rb_sys_fail("IO_Event_Selector_KQueue_process_wait:IO_Event_Selector_KQueue_Waiting_register");

--- a/ext/io/event/selector/selector.c
+++ b/ext/io/event/selector/selector.c
@@ -24,7 +24,7 @@ static VALUE rb_Process_Status = Qnil;
 
 VALUE IO_Event_Selector_process_status_wait(rb_pid_t pid, int flags)
 {
-	return rb_funcall(rb_Process_Status, id_wait, 2, PIDT2NUM(pid), INT2NUM(flags | WNOHANG));
+	return rb_funcall(rb_Process_Status, id_wait, 2, PIDT2NUM(pid), INT2NUM(flags));
 }
 #endif
 
@@ -80,8 +80,20 @@ static VALUE IO_Event_Selector_nonblock(VALUE class, VALUE io)
 	return rb_ensure(rb_yield, io, IO_Event_Selector_nonblock_ensure, (VALUE)&arguments);
 }
 
+static VALUE rb_IO_Event_Selector = Qnil;
+static ID id_process_wait;
+
+// Wait for a process when the selector cannot do so natively (e.g. `pid <= 0`: any child, or a process group). Delegates to the pure-Ruby `IO::Event::Selector.process_wait`, which performs a blocking wait on a separate thread; joining it is fiber-scheduler aware, so the reactor keeps running.
+VALUE IO_Event_Selector_process_wait(rb_pid_t pid, int flags) {
+	return rb_funcall(rb_IO_Event_Selector, id_process_wait, 2, PIDT2NUM(pid), INT2NUM(flags));
+}
+
 void Init_IO_Event_Selector(VALUE IO_Event_Selector) {
 	IO_Event_Selector_pending_interrupt_p_id = rb_intern("pending_interrupt?");
+	
+	rb_IO_Event_Selector = IO_Event_Selector;
+	rb_gc_register_mark_object(rb_IO_Event_Selector);
+	id_process_wait = rb_intern("process_wait");
 	
 #ifndef HAVE_RB_IO_DESCRIPTOR
 	id_fileno = rb_intern("fileno");

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -52,12 +52,20 @@ static inline int IO_Event_Selector_pending_interrupt(void) {
 int IO_Event_Selector_io_descriptor(VALUE io);
 #endif
 
-// Reap a process without hanging.
+// Wait for a process to change state. This blocks until the process changes state, unless `WNOHANG` is given in `flags`.
 #ifdef HAVE_RB_PROCESS_STATUS_WAIT
-#define IO_Event_Selector_process_status_wait(pid, flags) rb_process_status_wait(pid, flags | WNOHANG)
+#define IO_Event_Selector_process_status_wait(pid, flags) rb_process_status_wait(pid, flags)
 #else
 VALUE IO_Event_Selector_process_status_wait(rb_pid_t pid, int flags);
 #endif
+
+// Reap a process that is known to have changed state (e.g. after a readiness event), without blocking.
+static inline VALUE IO_Event_Selector_process_status_reap(rb_pid_t pid, int flags) {
+	return IO_Event_Selector_process_status_wait(pid, flags | WNOHANG);
+}
+
+// Wait for a process the selector cannot represent natively (e.g. `pid <= 0`: any child, or a process group), using a fiber-scheduler aware blocking wait on a separate thread.
+VALUE IO_Event_Selector_process_wait(rb_pid_t pid, int flags);
 
 int IO_Event_Selector_nonblock_set(int file_descriptor);
 void IO_Event_Selector_nonblock_restore(int file_descriptor, int flags);

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -561,10 +561,10 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	if (DEBUG) fprintf(stderr, "waitid result=%d pid=%d code=%d status=%d\n", result, arguments->siginfo.si_pid, arguments->siginfo.si_code, arguments->siginfo.si_status);
 	
 	// We waited with `WNOWAIT`, so the child has not been reaped yet. `si_pid` tells us exactly which child changed state (important when waiting for any child, e.g. pid -1). Reap it to obtain a correct `Process::Status`:
-	return IO_Event_Selector_process_status_wait(arguments->siginfo.si_pid, arguments->flags);
+	return IO_Event_Selector_process_status_reap(arguments->siginfo.si_pid, arguments->flags);
 #else
 	if (arguments->waiting->result) {
-		return IO_Event_Selector_process_status_wait(arguments->pid, arguments->flags);
+		return IO_Event_Selector_process_status_reap(arguments->pid, arguments->flags);
 	} else {
 		return Qfalse;
 	}
@@ -592,6 +592,11 @@ VALUE IO_Event_Selector_URing_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 	int flags = NUM2INT(_flags);
 	
 #ifndef IO_EVENT_SELECTOR_URING_USE_WAITID
+	// `pidfd_open` can only refer to a specific process, so waiting for any child or a process group (pid <= 0) is delegated to the threaded fallback:
+	if (pid <= 0) {
+		return IO_Event_Selector_process_wait(pid, flags);
+	}
+	
 	int descriptor = pidfd_open(pid, 0);
 	if (descriptor < 0) {
 		rb_syserr_fail(errno, "IO_Event_Selector_URing_process_wait:pidfd_open");

--- a/lib/io/event/selector.rb
+++ b/lib/io/event/selector.rb
@@ -40,5 +40,23 @@ module IO::Event
 			
 			return selector
 		end
+		
+		# Wait for a process to change state, for the cases a selector cannot represent natively (e.g. `pid <= 0`: any child, or a process group). The native selectors integrate process waiting with the event loop using per-process primitives (`pidfd_open`, `EVFILT_PROC`) which can only refer to a single, specific process, and delegate here otherwise.
+		#
+		# The wait is performed on a separate thread, which has no fiber scheduler and therefore blocks. Joining it via `Thread#value` is fiber-scheduler aware, so the calling fiber yields to the event loop and the reactor keeps running other fibers.
+		#
+		# @parameter pid [Integer] The process ID (or process group) to wait for.
+		# @parameter flags [Integer] Flags to pass to `Process::Status.wait`.
+		# @returns [Process::Status] The status of the waited process.
+		def self.process_wait(pid, flags)
+			thread = ::Thread.new do
+				::Process::Status.wait(pid, flags)
+			end
+			
+			thread.value
+		ensure
+			# If the calling fiber was interrupted before the wait completed, don't leave the thread running:
+			thread&.kill
+		end
 	end
 end

--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -278,9 +278,7 @@ module IO::Event
 			# @parameter flags [Integer] Flags to pass to Process::Status.wait.
 			# @returns [Process::Status] The status of the waited process.
 			def process_wait(fiber, pid, flags)
-				Thread.new do
-					Process::Status.wait(pid, flags)
-				end.value
+				Selector.process_wait(pid, flags)
 			end
 			
 			private def pop_ready

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
   - Use `io_uring_prep_waitid` for `process_wait` in the `URing` selector (Linux 6.7+), waiting for child exit directly in the ring instead of polling on a `pidfd`. The child is reaped via `rb_process_status_wait` (using `WEXITED | WNOWAIT`) to construct a correct `Process::Status`, and `process_wait(-1, ...)` / `process_wait(0, ...)` are now supported.
+  - Support waiting for any child or a process group (`pid <= 0`) on all selectors. The `EPoll` (`pidfd_open`) and `KQueue` (`EVFILT_PROC`) selectors can only watch a specific process, so these cases now fall back to a blocking wait on a dedicated thread; joining it is fiber-scheduler aware, so the reactor keeps running.
 
 ## v1.18.0
 

--- a/test/io/event/process.rb
+++ b/test/io/event/process.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "io/event"
+require "io/event/selector"
+require "io/event/test_scheduler"
+
+# Integration tests for the scheduler-dependent behaviour of `process_wait`. These properties only hold when a fiber scheduler is installed, so they are exercised here through `TestScheduler` rather than at the bare-selector level.
+ProcessWait = Sus::Shared("process wait") do
+	it "does not block the reactor while waiting for any child process" do
+		skip_if_ruby_platform(/mswin|mingw|cygwin/)
+		
+		order = []
+		
+		Fiber.set_scheduler(scheduler)
+		
+		Fiber.schedule do
+			Process.spawn("sleep 0.2")
+			Process.wait(-1)
+			order << :process
+		end
+		
+		Fiber.schedule do
+			sleep(0.01)
+			order << :sleep
+		end
+		
+		scheduler.run
+		
+		# If waiting for the process had blocked the reactor, the short sleep could not have completed first:
+		expect(order).to be == [:sleep, :process]
+	ensure
+		Fiber.set_scheduler(nil)
+	end
+	
+	it "can interrupt a process wait" do
+		skip_if_ruby_platform(/mswin|mingw|cygwin/)
+		
+		pid = Process.spawn("sleep 10")
+		error = nil
+		
+		Fiber.set_scheduler(scheduler)
+		
+		waiter = Fiber.schedule do
+			Process.wait(-1)
+		rescue => exception
+			error = exception
+		end
+		
+		Fiber.schedule do
+			scheduler.fiber_interrupt(waiter, StandardError.new("Interrupted!"))
+		end
+		
+		scheduler.run
+		
+		expect(error).to be_a(StandardError)
+	ensure
+		Process.kill(:KILL, pid) rescue nil
+		Process.wait(pid) rescue nil
+		Fiber.set_scheduler(nil)
+	end
+end
+
+IO::Event::Selector.constants.each do |name|
+	klass = IO::Event::Selector.const_get(name)
+	
+	describe(klass, unique: name) do
+		let(:selector) {klass.new(Fiber.current)}
+		let(:scheduler) {IO::Event::TestScheduler.new(selector: selector)}
+		
+		it_behaves_like ProcessWait
+	end
+end

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -676,6 +676,116 @@ Selector = Sus::Shared("a selector") do
 			expect(result1).to be(:success?)
 			expect(result2).to be(:success?)
 		end
+		
+		it "reports a non-zero exit status" do
+			result = nil
+			
+			fiber = Fiber.new do
+				pid = Process.spawn("exit 42", err: File::NULL)
+				result = selector.process_wait(Fiber.current, pid, 0)
+			end
+			
+			fiber.transfer
+			
+			while fiber.alive?
+				selector.select(0)
+			end
+			
+			expect(result).not.to be(:success?)
+			expect(result.exitstatus).to be == 42
+			expect(result).not.to be(:signaled?)
+		end
+		
+		it "reports termination by signal" do
+			skip_if_ruby_platform(/mswin|mingw|cygwin/)
+			
+			result = nil
+			
+			fiber = Fiber.new do
+				pid = Process.spawn("sleep 10")
+				Process.kill(:KILL, pid)
+				result = selector.process_wait(Fiber.current, pid, 0)
+			end
+			
+			fiber.transfer
+			
+			while fiber.alive?
+				selector.select(0)
+			end
+			
+			expect(result).to be(:signaled?)
+			expect(result.termsig).to be == Signal.list.fetch("KILL")
+		end
+		
+		it "can wait for any child process" do
+			result1 = result2 = nil
+			pids = []
+			
+			fiber = Fiber.new do
+				pid1 = Process.spawn("sleep 0")
+				pid2 = Process.spawn("sleep 0")
+				pids << pid1 << pid2
+				
+				result1 = selector.process_wait(Fiber.current, -1, 0)
+				result2 = selector.process_wait(Fiber.current, -1, 0)
+			end
+			
+			fiber.transfer
+			
+			while fiber.alive?
+				selector.select(0)
+			end
+			
+			expect(result1).to be(:success?)
+			expect(result2).to be(:success?)
+			
+			result_pids = [result1.pid, result2.pid].sort
+			expect(result_pids).to be == pids.sort
+		end
+		
+		it "can wait for any process in the caller's process group" do
+			skip_if_ruby_platform(/mswin|mingw|cygwin/)
+			
+			result = nil
+			pid = nil
+			
+			fiber = Fiber.new do
+				# Spawned in the caller's process group by default:
+				pid = Process.spawn("true")
+				result = selector.process_wait(Fiber.current, 0, 0)
+			end
+			
+			fiber.transfer
+			
+			while fiber.alive?
+				selector.select(0)
+			end
+			
+			expect(result).to be(:success?)
+			expect(result.pid).to be == pid
+		end
+		
+		it "can wait for any process in a specific process group" do
+			skip_if_ruby_platform(/mswin|mingw|cygwin/)
+			
+			result = nil
+			pid = nil
+			
+			fiber = Fiber.new do
+				# `pgroup: true` makes the child a leader of a new process group, so its process group id equals its pid:
+				pid = Process.spawn("true", pgroup: true)
+				result = selector.process_wait(Fiber.current, -pid, 0)
+			end
+			
+			fiber.transfer
+			
+			while fiber.alive?
+				selector.select(0)
+			end
+			
+			expect(result).to be(:success?)
+			expect(result.pid).to be == pid
+		end
 	end
 	
 	with "#resume" do


### PR DESCRIPTION
## Summary

Makes `process_wait` for **any child** or a **process group** (`pid <= 0`) work consistently on all selectors.

The `EPoll` (`pidfd_open`) and `KQueue` (`EVFILT_PROC`) selectors integrate process waiting with the event loop using per-process primitives that can only refer to a *specific positive* pid. So `process_wait(fiber, -1, 0)` / `process_wait(fiber, 0, 0)` / negative-pgid waits previously failed with a cryptic `Errno::EINVAL`. This matters because `Process.wait` / `Process.waitall` default to `pid = -1`, and the pure-Ruby `Select` selector already handled these — so the native selectors were actually *less* correct than the fallback.

## Approach

A single shared fallback, `IO::Event::Selector.process_wait(pid, flags)` (pure Ruby):

```ruby
def self.process_wait(pid, flags)
  thread = ::Thread.new do
    ::Process::Status.wait(pid, flags)
  end
  thread.value
ensure
  thread&.kill
end
```

The wait runs on a separate thread (which has no fiber scheduler, so it blocks and does not recurse into the `process_wait` hook). Joining it via `Thread#value` is **fiber-scheduler aware**, so the calling fiber yields to the event loop and the reactor keeps running other fibers. Because `pid`/`flags` are ordinary Ruby objects captured in the block, there is no manual memory management and no cross-thread stack lifetime to get wrong.

- `EPoll`, `KQueue`, and the `URing` pidfd fallback delegate to it (via the C helper `IO_Event_Selector_process_wait`) **only when `pid <= 0`**; the `pid > 0` fast paths (pidfd/`EVFILT_PROC`/waitid) are untouched.
- The `URing` waitid path already supports `pid <= 0` natively via `P_ALL`/`P_PGID`.
- The pure-Ruby `Select#process_wait` now delegates to the same method, so there is exactly one implementation.

This is a fallback for the cases modern Linux io_uring handles natively; it favours simplicity and correctness over raw throughput (it spawns a thread per outstanding wait).

Also splits waiting from reaping for clarity: `IO_Event_Selector_process_status_wait` is now a faithful (blocking) wrapper, and a new inline `IO_Event_Selector_process_status_reap` makes the non-blocking reap-after-readiness explicit at the call sites.

## Tests

- **Unit** (bare selector, across all selectors): non-zero exit status, termination by signal, and waiting for any child / the caller's process group / a specific process group.
- **Integration** (`test/io/event/process.rb`, via `TestScheduler`): asserts the wait does not block the reactor, and can be interrupted.

## Verification

- macOS (KQueue + Select): green.
- Linux (EPoll + URing-waitid + URing-pidfd-fallback + Select): green.
- ASan ("Test Debug" / asan on ASan-instrumented Ruby): green.

## Background Context

@noteflakes this follows up on your `io_uring_prep_waitid` work in #154. While reviewing it we found the `pid <= 0` (wait-for-any-child / process-group) cases are a general gap across the native selectors, not just `URing`:

- `pidfd_open(pid)` (EPoll, and the `URing` pidfd fallback) requires a *specific positive* pid — `pidfd_open(-1)` / negative pgid returns `EINVAL`.
- `EVFILT_PROC` (KQueue) likewise can only watch one concrete pid.
- Only your `URing` + `waitid` path expresses these natively (`P_ALL` / `P_PGID`), and the pure-Ruby `Select` selector handled them via a thread.

The fix here is the threaded fallback described above for the selectors that can't do it natively, so `Process.wait(-1)` / `Process.waitall` behave consistently everywhere. Your `waitid` path remains the fast, fully-native implementation on modern Linux. Thanks again for kicking this off!