### PR TITLE
Fix Process.waitall/detach under URing selector when no children remain

### DIFF
--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -554,11 +554,13 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	
 #ifdef IO_EVENT_SELECTOR_URING_USE_WAITID
 	int32_t result = arguments->waiting->result;
-	if (result < 0) {
-		rb_syserr_fail(-result, "IO_Event_Selector_URing_process_wait:io_uring_prep_waitid");
-	}
 	
 	if (DEBUG) fprintf(stderr, "waitid result=%d pid=%d code=%d status=%d\n", result, arguments->siginfo.si_pid, arguments->siginfo.si_code, arguments->siginfo.si_status);
+	
+	if (result < 0) {
+		// The `waitid` failed (e.g. `ECHILD` when there are no children). Reproduce the failure as a `Process::Status` carrying the error, rather than raising, so callers like `Process.waitall` / `Process.detach` (which expect `waitpid` to report the error, not raise) behave correctly:
+		return IO_Event_Selector_process_status_reap(arguments->pid, arguments->flags);
+	}
 	
 	// We waited with `WNOWAIT`, so the child has not been reaped yet. `si_pid` tells us exactly which child changed state (important when waiting for any child, e.g. pid -1). Reap it to obtain a correct `Process::Status`:
 	return IO_Event_Selector_process_status_reap(arguments->siginfo.si_pid, arguments->flags);

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Fix `Process.waitall` / `Process.detach` under the `URing` selector: when `io_uring`'s `waitid` reported an error (e.g. `ECHILD` when there are no more children), the `process_wait` hook raised instead of returning the error as a `Process::Status`, so callers that expect `waitpid` to *report* "no more children" rather than raise would fail.
+
 ## v1.19.0
 
   - Use `io_uring_prep_waitid` for `process_wait` in the `URing` selector (Linux 6.7+), waiting for child exit directly in the ring instead of polling on a `pidfd`. The child is reaped via `rb_process_status_wait` (using `WEXITED | WNOWAIT`) to construct a correct `Process::Status`, and `process_wait(-1, ...)` / `process_wait(0, ...)` are now supported.

--- a/test/io/event/process.rb
+++ b/test/io/event/process.rb
@@ -35,6 +35,51 @@ ProcessWait = Sus::Shared("process wait") do
 		Fiber.set_scheduler(nil)
 	end
 	
+	it "can wait for all child processes" do
+		skip_if_ruby_platform(/mswin|mingw|cygwin/)
+		
+		statuses = nil
+		
+		Fiber.set_scheduler(scheduler)
+		
+		Fiber.schedule do
+			3.times{Process.spawn("true")}
+			
+			# `Process.waitall` loops `Process.wait(-1)` until `ECHILD`, relying on the final wait reporting "no more children" rather than raising. The scheduler hook must surface that as a result, not an exception:
+			statuses = Process.waitall
+		end
+		
+		scheduler.run
+		
+		expect(statuses.size).to be == 3
+		statuses.each do |pid, status|
+			expect(status).to be(:success?)
+		end
+	ensure
+		Fiber.set_scheduler(nil)
+	end
+	
+	it "raises when waiting for any child process with no children" do
+		skip_if_ruby_platform(/mswin|mingw|cygwin/)
+		
+		error = nil
+		
+		Fiber.set_scheduler(scheduler)
+		
+		Fiber.schedule do
+			Process.wait(-1)
+		rescue SystemCallError => exception
+			error = exception
+		end
+		
+		scheduler.run
+		
+		# Consistent with non-scheduler `Process.wait(-1)`: no children is `Errno::ECHILD`.
+		expect(error).to be_a(Errno::ECHILD)
+	ensure
+		Fiber.set_scheduler(nil)
+	end
+	
 	it "can interrupt a process wait" do
 		skip_if_ruby_platform(/mswin|mingw|cygwin/)
 		


### PR DESCRIPTION
## Summary

Fixes `Process.waitall` / `Process.detach` under the `URing` selector when there are no more children to reap.

## The bug

The `URing` selector's `process_wait` hook (the `io_uring` `waitid` path) raised via `rb_syserr_fail` when `waitid` reported an error such as `ECHILD`:

```c
if (result < 0) {
    rb_syserr_fail(-result, "...:io_uring_prep_waitid");
}
```

But `Process.waitall` (and `Process.detach`) rely on `rb_waitpid` **returning** `-1` with `errno == ECHILD` so they can terminate their loops — they do *not* expect it to raise (see `proc_waitall` in Ruby's `process.c`). Under a fiber scheduler this path goes through the hook, so raising broke them: `Process.waitall` would propagate `Errno::ECHILD` instead of returning the statuses it had already collected.

`Process.wait(-1)` with no children still raises `Errno::ECHILD` — that's correct and unchanged (it matches non-scheduler behaviour).

The threaded fallback (EPoll / KQueue / Select) was already correct, because it reaps via `Process::Status.wait`, which returns the proper `(-1, errno)` carrier rather than raising.

## The fix

Route `waitid` errors through the same `WNOHANG` reap already used on the success path. `rb_process_status_wait(pid, flags | WNOHANG)` reproduces the failure as a `Process::Status` carrying `(pid -1, errno)`, exactly like `Process::Status.wait` — so `rb_waitpid` reports it correctly and `waitall`/`detach` behave as expected. No new API required.

## Tests

Adds integration tests (via `TestScheduler`, across all selectors):
- `Process.waitall` collects all child statuses and terminates cleanly.
- `Process.wait(-1)` with no children raises `Errno::ECHILD` (regression guard for the corrected behaviour).

## Verification

- Reproduced first: the new `waitall` test errors with `Errno::ECHILD` only on the `URing` waitid path (EPoll/Select pass).
- With the fix: green on Linux (EPoll + URing-waitid + Select) — 150/150 — and macOS (KQueue + Select) — 112/112.

## Background

This came out of the discussion on [bug #21704](https://bugs.ruby-lang.org/issues/21704) about exposing `rb_process_status_new`. Notably this fix needs **no** new Ruby API — `rb_process_status_wait` already provides the full-fidelity reap (including the error carrier). A constructor like `rb_process_status_new` would only be needed later to avoid the extra reap syscall on the success path.
