### PR TITLE
Update rb_nogvl pending interrupt flag name

### DIFF
--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -847,8 +847,8 @@ int select_blocking_allowed(struct timespec * timespec) {
 		return 0;
 	}
 	
-#ifndef RB_NOGVL_PENDING_INTERRUPT_FAIL
-	// On Rubies without `RB_NOGVL_PENDING_INTERRUPT_FAIL`, `rb_thread_call_without_gvl2` can enter an indefinite native wait even if a masked interrupt is already pending for this thread. This is the last safe point to avoid that wait: we still hold the GVL, so the pending interrupt queue cannot change concurrently before we decide whether to enter the blocking path.
+#ifndef RB_NOGVL_PENDING_INTR_FAIL
+	// On Rubies without `RB_NOGVL_PENDING_INTR_FAIL`, `rb_thread_call_without_gvl2` can enter an indefinite native wait even if a masked interrupt is already pending for this thread. This is the last safe point to avoid that wait: we still hold the GVL, so the pending interrupt queue cannot change concurrently before we decide whether to enter the blocking path.
 	if (IO_Event_Selector_pending_interrupt()) {
 		return 0;
 	}
@@ -919,8 +919,8 @@ static
 int select_internal_without_gvl(struct select_arguments *arguments) {
 	arguments->result = -1;
 	arguments->selector->blocked = 1;
-#ifdef RB_NOGVL_PENDING_INTERRUPT_FAIL
-	rb_nogvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0, RB_NOGVL_INTR_FAIL | RB_NOGVL_PENDING_INTERRUPT_FAIL);
+#ifdef RB_NOGVL_PENDING_INTR_FAIL
+	rb_nogvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0, RB_NOGVL_INTR_FAIL | RB_NOGVL_PENDING_INTR_FAIL);
 #else
 	rb_thread_call_without_gvl2(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
 #endif

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -851,8 +851,8 @@ int select_blocking_allowed(struct timespec * timespec) {
 		return 0;
 	}
 	
-#ifndef RB_NOGVL_PENDING_INTERRUPT_FAIL
-	// On Rubies without `RB_NOGVL_PENDING_INTERRUPT_FAIL`, `rb_thread_call_without_gvl2` can enter an indefinite native wait even if a masked interrupt is already pending for this thread. This is the last safe point to avoid that wait: we still hold the GVL, so the pending interrupt queue cannot change concurrently before we decide whether to enter the blocking path.
+#ifndef RB_NOGVL_PENDING_INTR_FAIL
+	// On Rubies without `RB_NOGVL_PENDING_INTR_FAIL`, `rb_thread_call_without_gvl2` can enter an indefinite native wait even if a masked interrupt is already pending for this thread. This is the last safe point to avoid that wait: we still hold the GVL, so the pending interrupt queue cannot change concurrently before we decide whether to enter the blocking path.
 	if (IO_Event_Selector_pending_interrupt()) {
 		return 0;
 	}
@@ -888,8 +888,8 @@ int select_internal_without_gvl(struct select_arguments *arguments) {
 	arguments->result = -1;
 	arguments->selector->blocked = 1;
 	
-#ifdef RB_NOGVL_PENDING_INTERRUPT_FAIL
-	rb_nogvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0, RB_NOGVL_INTR_FAIL | RB_NOGVL_PENDING_INTERRUPT_FAIL);
+#ifdef RB_NOGVL_PENDING_INTR_FAIL
+	rb_nogvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0, RB_NOGVL_INTR_FAIL | RB_NOGVL_PENDING_INTR_FAIL);
 #else
 	rb_thread_call_without_gvl2(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
 #endif

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -1211,8 +1211,8 @@ int select_blocking_allowed(struct __kernel_timespec *timespec) {
 		return 0;
 	}
 	
-#ifndef RB_NOGVL_PENDING_INTERRUPT_FAIL
-	// On Rubies without `RB_NOGVL_PENDING_INTERRUPT_FAIL`, `rb_thread_call_without_gvl2` can enter an indefinite native wait even if a masked interrupt is already pending for this thread. This is the last safe point to avoid that wait: we still hold the GVL, so the pending interrupt queue cannot change concurrently before we decide whether to enter the blocking path.
+#ifndef RB_NOGVL_PENDING_INTR_FAIL
+	// On Rubies without `RB_NOGVL_PENDING_INTR_FAIL`, `rb_thread_call_without_gvl2` can enter an indefinite native wait even if a masked interrupt is already pending for this thread. This is the last safe point to avoid that wait: we still hold the GVL, so the pending interrupt queue cannot change concurrently before we decide whether to enter the blocking path.
 	if (IO_Event_Selector_pending_interrupt()) {
 		return 0;
 	}
@@ -1259,8 +1259,8 @@ int select_internal_without_gvl(struct select_arguments *arguments) {
 	
 	arguments->result = -EINTR;
 	selector->blocked = 1;
-#ifdef RB_NOGVL_PENDING_INTERRUPT_FAIL
-	rb_nogvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0, RB_NOGVL_INTR_FAIL | RB_NOGVL_PENDING_INTERRUPT_FAIL);
+#ifdef RB_NOGVL_PENDING_INTR_FAIL
+	rb_nogvl(select_internal, (void *)arguments, RUBY_UBF_IO, 0, RB_NOGVL_INTR_FAIL | RB_NOGVL_PENDING_INTR_FAIL);
 #else
 	rb_thread_call_without_gvl2(select_internal, (void *)arguments, RUBY_UBF_IO, 0);
 #endif


### PR DESCRIPTION
## Summary

- Update selector feature checks to use `RB_NOGVL_PENDING_INTR_FAIL`, matching the renamed CRuby PR flag.
- Keep the compatibility fallback for Rubies without the new flag unchanged.

## Testing

- `PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH ruby -Ilib -Iext ext/extconf.rb`
- `PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH make`

Note: `bundle exec bake build` could not run locally because Bundler/tec failed while resolving the dev environment before invoking io-event commands.