### PR TITLE
Use rb_process_status_for for waitid results

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -51,6 +51,7 @@ have_header("sys/eventfd.h")
 $srcs << "io/event/interrupt.c"
 
 have_func("rb_io_descriptor")
+have_func("rb_process_status_for")
 have_func("&rb_process_status_wait")
 have_func("rb_fiber_current")
 have_func("&rb_fiber_raise")

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -52,6 +52,7 @@ static inline int IO_Event_Selector_pending_interrupt(void) {
 int IO_Event_Selector_io_descriptor(VALUE io);
 #endif
 
+// Wait for a process to change state. This blocks until the process changes state, unless `WNOHANG` is given in `flags`.
 #ifdef HAVE_RB_PROCESS_STATUS_WAIT
 #define IO_Event_Selector_process_status_wait(pid, flags) rb_process_status_wait(pid, flags)
 #else

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -53,6 +53,10 @@ int IO_Event_Selector_io_descriptor(VALUE io);
 #endif
 
 // Wait for a process to change state. This blocks until the process changes state, unless `WNOHANG` is given in `flags`.
+#ifdef HAVE_RB_PROCESS_STATUS_FOR
+#define IO_Event_Selector_process_status_for(pid, status, error) rb_process_status_for(pid, status, error)
+#endif
+
 #ifdef HAVE_RB_PROCESS_STATUS_WAIT
 #define IO_Event_Selector_process_status_wait(pid, flags) rb_process_status_wait(pid, flags)
 #else

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -52,11 +52,6 @@ static inline int IO_Event_Selector_pending_interrupt(void) {
 int IO_Event_Selector_io_descriptor(VALUE io);
 #endif
 
-// Wait for a process to change state. This blocks until the process changes state, unless `WNOHANG` is given in `flags`.
-#ifdef HAVE_RB_PROCESS_STATUS_FOR
-#define IO_Event_Selector_process_status_for(pid, status, error) rb_process_status_for(pid, status, error)
-#endif
-
 #ifdef HAVE_RB_PROCESS_STATUS_WAIT
 #define IO_Event_Selector_process_status_wait(pid, flags) rb_process_status_wait(pid, flags)
 #else

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -583,7 +583,7 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	if (result < 0) {
 		// The `waitid` failed (e.g. `ECHILD` when there are no children). Reproduce the failure as a `Process::Status` carrying the error, rather than raising, so callers like `Process.waitall` / `Process.detach` (which expect `waitpid` to report the error, not raise) behave correctly:
 #ifdef HAVE_RB_PROCESS_STATUS_FOR
-		return IO_Event_Selector_process_status_for(-1, 0, -result);
+		return rb_process_status_for(-1, 0, -result);
 #else
 		return IO_Event_Selector_process_status_reap(arguments->pid, arguments->flags);
 #endif
@@ -591,7 +591,7 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	
 #ifdef HAVE_RB_PROCESS_STATUS_FOR
 	// The `waitid` operation already reaped the child. Convert the `siginfo_t` result directly into the Ruby process status value:
-	return IO_Event_Selector_process_status_for(arguments->siginfo.si_pid, process_wait_status_from_siginfo(&arguments->siginfo), 0);
+	return rb_process_status_for(arguments->siginfo.si_pid, process_wait_status_from_siginfo(&arguments->siginfo), 0);
 #else
 	// We waited with `WNOWAIT`, so the child has not been reaped yet. `si_pid` tells us exactly which child changed state (important when waiting for any child, e.g. pid -1). Reap it to obtain a correct `Process::Status`:
 	return IO_Event_Selector_process_status_reap(arguments->siginfo.si_pid, arguments->flags);

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -546,6 +546,29 @@ struct process_wait_arguments {
 #endif
 };
 
+#if defined(IO_EVENT_SELECTOR_URING_USE_WAITID) && defined(HAVE_RB_PROCESS_STATUS_FOR)
+static inline int process_wait_status_exited(int exit_status) {
+	return (exit_status & 0xff) << 8;
+}
+
+static inline int process_wait_status_signaled(int term_signal) {
+	return term_signal & 0x7f;
+}
+
+static inline int process_wait_status_from_siginfo(const siginfo_t *siginfo) {
+	switch (siginfo->si_code) {
+		case CLD_EXITED:
+			return process_wait_status_exited(siginfo->si_status);
+		case CLD_KILLED:
+			return process_wait_status_signaled(siginfo->si_status);
+		case CLD_DUMPED:
+			return process_wait_status_signaled(siginfo->si_status) | 0x80;
+		default:
+			return 0;
+	}
+}
+#endif
+
 static
 VALUE process_wait_transfer(VALUE _arguments) {
 	struct process_wait_arguments *arguments = (struct process_wait_arguments *)_arguments;
@@ -559,11 +582,20 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	
 	if (result < 0) {
 		// The `waitid` failed (e.g. `ECHILD` when there are no children). Reproduce the failure as a `Process::Status` carrying the error, rather than raising, so callers like `Process.waitall` / `Process.detach` (which expect `waitpid` to report the error, not raise) behave correctly:
+#ifdef HAVE_RB_PROCESS_STATUS_FOR
+		return IO_Event_Selector_process_status_for(-1, 0, -result);
+#else
 		return IO_Event_Selector_process_status_reap(arguments->pid, arguments->flags);
+#endif
 	}
 	
+#ifdef HAVE_RB_PROCESS_STATUS_FOR
+	// The `waitid` operation already reaped the child. Convert the `siginfo_t` result directly into the Ruby process status value:
+	return IO_Event_Selector_process_status_for(arguments->siginfo.si_pid, process_wait_status_from_siginfo(&arguments->siginfo), 0);
+#else
 	// We waited with `WNOWAIT`, so the child has not been reaped yet. `si_pid` tells us exactly which child changed state (important when waiting for any child, e.g. pid -1). Reap it to obtain a correct `Process::Status`:
 	return IO_Event_Selector_process_status_reap(arguments->siginfo.si_pid, arguments->flags);
+#endif
 #else
 	if (arguments->waiting->result) {
 		return IO_Event_Selector_process_status_reap(arguments->pid, arguments->flags);
@@ -632,8 +664,13 @@ VALUE IO_Event_Selector_URing_process_wait(VALUE self, VALUE fiber, VALUE _pid, 
 	id_t id;
 	idtype_t idtype = process_waitid_type(pid, &id);
 	if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_process_wait:io_uring_prep_waitid(fiber=%p, idtype=%d, id=%d, flags=%d)\n", (void*)fiber, idtype, (int)id, flags);
+#ifdef HAVE_RB_PROCESS_STATUS_FOR
+	// Reap the child directly; the completion contains enough information to construct the Ruby process status value:
+	io_uring_prep_waitid(sqe, idtype, id, &process_wait_arguments.siginfo, WEXITED, 0);
+#else
 	// `WNOWAIT` leaves the child in a waitable state so we can reap it with `rb_process_status_wait` afterwards and build a correct `Process::Status`:
 	io_uring_prep_waitid(sqe, idtype, id, &process_wait_arguments.siginfo, WEXITED | WNOWAIT, 0);
+#endif
 #else
 	if (DEBUG) fprintf(stderr, "IO_Event_Selector_URing_process_wait:io_uring_prep_poll_add(%p)\n", (void*)fiber);
 	io_uring_prep_poll_add(sqe, descriptor, POLLIN|POLLHUP|POLLERR);

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ Please see the [project documentation](https://socketry.github.io/io-event/) for
 
 Please see the [project releases](https://socketry.github.io/io-event/releases/index) for all releases.
 
-### v1.19.2
+### Unreleased
 
   - Use `rb_process_status_for` when available to construct `URing` `process_wait` results directly from `waitid`, avoiding the extra reap syscall previously needed to build a `Process::Status`.
 

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,10 @@ Please see the [project documentation](https://socketry.github.io/io-event/) for
 
 Please see the [project releases](https://socketry.github.io/io-event/releases/index) for all releases.
 
+### v1.19.2
+
+  - Use `rb_process_status_for` when available to construct `URing` `process_wait` results directly from `waitid`, avoiding the extra reap syscall previously needed to build a `Process::Status`.
+
 ### v1.19.1
 
   - Fix `Process.waitall` / `Process.detach` under the `URing` selector: when `io_uring`'s `waitid` reported an error (e.g. `ECHILD` when there are no more children), the `process_wait` hook raised instead of returning the error as a `Process::Status`, so callers that expect `waitpid` to *report* "no more children" rather than raise would fail.

--- a/releases.md
+++ b/releases.md
@@ -1,6 +1,6 @@
 # Releases
 
-## v1.19.2
+## Unreleased
 
   - Use `rb_process_status_for` when available to construct `URing` `process_wait` results directly from `waitid`, avoiding the extra reap syscall previously needed to build a `Process::Status`.
 

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## v1.19.2
+
+  - Use `rb_process_status_for` when available to construct `URing` `process_wait` results directly from `waitid`, avoiding the extra reap syscall previously needed to build a `Process::Status`.
+
 ## v1.19.1
 
   - Fix `Process.waitall` / `Process.detach` under the `URing` selector: when `io_uring`'s `waitid` reported an error (e.g. `ECHILD` when there are no more children), the `process_wait` hook raised instead of returning the error as a `Process::Status`, so callers that expect `waitpid` to *report* "no more children" rather than raise would fail.

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -726,7 +726,7 @@ Selector = Sus::Shared("a selector") do
 			pid = Process.spawn(*command, **spawn_options)
 			_, expected = Process.wait2(pid)
 			
-			skip_unless(expected.respond_to?(:coredump?) && expected.coredump?, "core dump status is not reported on this platform")
+			next unless expected.respond_to?(:coredump?) && expected.coredump?
 			
 			result = nil
 			

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -717,6 +717,35 @@ Selector = Sus::Shared("a selector") do
 			expect(result.termsig).to be == Signal.list.fetch("KILL")
 		end
 		
+		it "reports termination by signal with a core dump" do
+			skip_if_ruby_platform(/darwin|mswin|mingw|cygwin/)
+			
+			command = ["ruby", "-e", "Process.kill(:ABRT, $$)"]
+			spawn_options = {out: File::NULL, err: File::NULL, rlimit_core: 0}
+			
+			pid = Process.spawn(*command, **spawn_options)
+			_, expected = Process.wait2(pid)
+			
+			skip_unless(expected.respond_to?(:coredump?) && expected.coredump?, "core dump status is not reported on this platform")
+			
+			result = nil
+			
+			fiber = Fiber.new do
+				pid = Process.spawn(*command, **spawn_options)
+				result = selector.process_wait(Fiber.current, pid, 0)
+			end
+			
+			fiber.transfer
+			
+			while fiber.alive?
+				selector.select(0)
+			end
+			
+			expect(result).to be(:signaled?)
+			expect(result.termsig).to be == expected.termsig
+			expect(result).to be(:coredump?)
+		end
+		
 		it "can wait for any child process" do
 			result1 = result2 = nil
 			pids = []


### PR DESCRIPTION
## Summary
- detect the new Ruby `rb_process_status_for` C API
- use it in the URing `waitid` path to construct process wait results directly
- keep the existing `rb_process_status_wait` reap fallback for older Rubies
- document the optimization in the release notes

## Testing
- `make` in `ext`
- `bundle exec sus test/io/event/selector.rb`

Note: local macOS build does not compile the Linux URing path because `liburing` is unavailable here.