### PR TITLE
Update expected output in getting started guide for Ruby 3.4+

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -47,7 +47,7 @@ writer.transfer
 selector.select(1)
 
 # Results in:
-# {:read=>"Hello World"}
+# {read: "Hello World"}
 ```
 
 ## Debugging


### PR DESCRIPTION
The "Basic Event Loop" example in the getting started guide shows the expected output as `{:read=>"Hello World"}`. Since Ruby 3.4, `Hash#inspect` uses a new format (see [Feature #16295](https://bugs.ruby-lang.org/issues/16295)), so running the example as-is on current Ruby versions actually prints:

```
{read: "Hello World"}
```

This updates the expected output to match what readers will see on Ruby 3.4+. On Ruby 3.3 (which this gem still supports) the old format is shown — happy to add a note mentioning that if you prefer.

Verified by running the example unchanged on Ruby 3.4.10 (macOS arm64).

## Types of Changes

- Maintenance.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).