### PR TITLE
Make the Basic Event Loop example show the flow of control

### DIFF
--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -25,29 +25,55 @@ This example shows how to perform a blocking operation
 require "fiber"
 require "io/event"
 
+# Create an I/O event selector controlled by the main Fiber.
 selector = IO::Event::Selector.new(Fiber.current)
+
+# input: read end, output: write end.
 input, output = IO.pipe
 
 writer = Fiber.new do
+	puts "[writer] Writing data"
+
 	output.write("Hello World")
 	output.close
 end
 
 reader = Fiber.new do
-	selector.io_wait(Fiber.current, input, IO::READABLE)
-	pp read: input.read
+	puts "[reader] No data available, waiting for input"
+
+	# Suspend this Fiber until the input becomes readable.
+	selector.io_wait(
+		Fiber.current,
+		input,
+		IO::READABLE
+	)
+
+	# Execution resumes here once the selector detects the event.
+	puts "[reader] Received: #{input.read.inspect}"
 end
 
-# The reader will be blocked until the IO has data available:
+puts "[main] Transferring to reader fiber"
 reader.transfer
 
-# Write some data to the pipe and close the writing end:
+puts "[main] Reader is waiting, but main can keep running"
+
+puts "[main] Transferring to writer fiber"
 writer.transfer
 
+puts "[main] Checking for I/O events"
 selector.select(1)
 
+puts "[main] Done"
+
 # Results in:
-# {:read=>"Hello World"}
+# [main] Transferring to reader fiber
+# [reader] No data available, waiting for input
+# [main] Reader is waiting, but main can keep running
+# [main] Transferring to writer fiber
+# [writer] Writing data
+# [main] Checking for I/O events
+# [reader] Received: "Hello World"
+# [main] Done
 ```
 
 ## Debugging

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -32,18 +32,14 @@ selector = IO::Event::Selector.new(Fiber.current)
 input, output = IO.pipe
 
 writer = Fiber.new do
-	puts "[writer] Started"
-	puts "[writer] Writing data..."
+	puts "[writer] Writing data"
 
 	output.write("Hello World")
 	output.close
-
-	puts "[writer] Finished"
 end
 
 reader = Fiber.new do
-	puts "[reader] Started"
-	puts "[reader] No data available. Waiting for input..."
+	puts "[reader] No data available, waiting for input"
 
 	# Suspend this Fiber until the input becomes readable.
 	selector.io_wait(
@@ -54,15 +50,14 @@ reader = Fiber.new do
 
 	# Execution resumes here once the selector detects the event.
 	puts "[reader] Received: #{input.read.inspect}"
-	puts "[reader] Finished"
 end
 
-puts "[main] Starting reader"
+puts "[main] Transferring to reader fiber"
 reader.transfer
 
-puts "[main] The reader is waiting, but I can keep running"
+puts "[main] Reader is waiting, but main can keep running"
 
-puts "[main] Starting writer"
+puts "[main] Transferring to writer fiber"
 writer.transfer
 
 puts "[main] Checking for I/O events"
@@ -71,17 +66,13 @@ selector.select(1)
 puts "[main] Done"
 
 # Results in:
-# [main] Starting reader
-# [reader] Started
-# [reader] No data available. Waiting for input...
-# [main] The reader is waiting, but I can keep running
-# [main] Starting writer
-# [writer] Started
-# [writer] Writing data...
-# [writer] Finished
+# [main] Transferring to reader fiber
+# [reader] No data available, waiting for input
+# [main] Reader is waiting, but main can keep running
+# [main] Transferring to writer fiber
+# [writer] Writing data
 # [main] Checking for I/O events
 # [reader] Received: "Hello World"
-# [reader] Finished
 # [main] Done
 ```
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -25,29 +25,64 @@ This example shows how to perform a blocking operation
 require "fiber"
 require "io/event"
 
+# Create an I/O event selector controlled by the main Fiber.
 selector = IO::Event::Selector.new(Fiber.current)
+
+# input: read end, output: write end.
 input, output = IO.pipe
 
 writer = Fiber.new do
+	puts "[writer] Started"
+	puts "[writer] Writing data..."
+
 	output.write("Hello World")
 	output.close
+
+	puts "[writer] Finished"
 end
 
 reader = Fiber.new do
-	selector.io_wait(Fiber.current, input, IO::READABLE)
-	pp read: input.read
+	puts "[reader] Started"
+	puts "[reader] No data available. Waiting for input..."
+
+	# Suspend this Fiber until the input becomes readable.
+	selector.io_wait(
+		Fiber.current,
+		input,
+		IO::READABLE
+	)
+
+	# Execution resumes here once the selector detects the event.
+	puts "[reader] Received: #{input.read.inspect}"
+	puts "[reader] Finished"
 end
 
-# The reader will be blocked until the IO has data available:
+puts "[main] Starting reader"
 reader.transfer
 
-# Write some data to the pipe and close the writing end:
+puts "[main] The reader is waiting, but I can keep running"
+
+puts "[main] Starting writer"
 writer.transfer
 
+puts "[main] Checking for I/O events"
 selector.select(1)
 
+puts "[main] Done"
+
 # Results in:
-# {:read=>"Hello World"}
+# [main] Starting reader
+# [reader] Started
+# [reader] No data available. Waiting for input...
+# [main] The reader is waiting, but I can keep running
+# [main] Starting writer
+# [writer] Started
+# [writer] Writing data...
+# [writer] Finished
+# [main] Checking for I/O events
+# [reader] Received: "Hello World"
+# [reader] Finished
+# [main] Done
 ```
 
 ## Debugging


### PR DESCRIPTION
When I read the Basic Event Loop example for the first time, I couldn't tell what it was demonstrating: the final output is identical to what blocking IO would produce, and the most important fact — that `io_wait` suspends the reader *without blocking the program* — is not visible anywhere in the output.

This PR tries to make the flow of control visible:

- `[main]` / `[reader]` / `[writer]` labels show which fiber each line comes from.
- Comments mark exactly where the reader suspends and where execution resumes.
- The expected output shows `[main]` lines appearing *while the reader is waiting* — an ordering that would be impossible with blocking IO.

I verified the example runs unchanged on Ruby 3.4.10 (macOS arm64) and produces exactly the output shown. (This also sidesteps the `Hash#inspect` format issue addressed in #207, since the example no longer prints a Hash.)

**Open question**: I'm genuinely unsure about the trade-off — this version is much longer than the original 12 lines. Would you prefer:

- (a) this fully annotated version,
- (b) a shorter version with fewer log lines, or
- (c) keeping the original code and only adding an expected-output block?

Happy to rework it in any direction.

## Types of Changes

- Maintenance.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).