### PR TITLE
Support fiber scheduler interface version 4

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,6 +23,7 @@ jobs:
           - "3.3"
           - "3.4"
           - "4.0"
+          - "head"
     
     steps:
     - uses: actions/checkout@v6

--- a/benchmark/server/scheduler.rb
+++ b/benchmark/server/scheduler.rb
@@ -70,18 +70,18 @@ class Scheduler
 end
 
 class DirectScheduler < Scheduler
-	def io_read(io, buffer, length)
+	def io_read(io, buffer, *arguments)
 		fiber = Fiber.current
 		@waiting += 1
-		result = @selector.io_read(fiber, io, buffer, length)
+		@selector.io_read(fiber, io, buffer, *arguments)
 	ensure
 		@waiting -= 1
 	end
 	
-	def io_write(io, buffer, length)
+	def io_write(io, buffer, *arguments)
 		fiber = Fiber.current
 		@waiting += 1
-		@selector.io_write(fiber, io, buffer, length)
+		@selector.io_write(fiber, io, buffer, *arguments)
 	ensure
 		@waiting -= 1
 	end

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -33,21 +33,21 @@ input, output = IO.pipe
 
 writer = Fiber.new do
 	puts "[writer] Writing data"
-
+	
 	output.write("Hello World")
 	output.close
 end
 
 reader = Fiber.new do
 	puts "[reader] No data available, waiting for input"
-
+	
 	# Suspend this Fiber until the input becomes readable.
 	selector.io_wait(
 		Fiber.current,
 		input,
 		IO::READABLE
 	)
-
+	
 	# Execution resumes here once the selector detects the event.
 	puts "[reader] Received: #{input.read.inspect}"
 end

--- a/ext/io/event/selector/epoll.c
+++ b/ext/io/event/selector/epoll.c
@@ -593,9 +593,11 @@ VALUE IO_Event_Selector_EPoll_io_wait(VALUE self, VALUE fiber, VALUE io, VALUE e
 #ifdef HAVE_RUBY_IO_BUFFER_H
 
 struct io_read_arguments {
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 	VALUE self;
 	VALUE fiber;
 	VALUE io;
+#endif
 	
 	int flags;
 	
@@ -605,14 +607,20 @@ struct io_read_arguments {
 	void *base;
 	size_t size;
 	
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 	// The minimum number of bytes requested by the caller.
 	size_t length;
+#endif
 };
 
 static
 VALUE io_read_loop(VALUE _arguments) {
 	struct io_read_arguments *arguments = (struct io_read_arguments *)_arguments;
 	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	ssize_t result = read(arguments->descriptor, arguments->base, arguments->size);
+	return rb_fiber_scheduler_io_result(result, errno);
+#else
 	size_t length = arguments->length;
 	size_t total = 0;
 	
@@ -635,6 +643,7 @@ VALUE io_read_loop(VALUE _arguments) {
 	}
 	
 	return rb_fiber_scheduler_io_result(total, 0);
+#endif
 }
 
 static
@@ -646,13 +655,26 @@ VALUE io_read_ensure(VALUE _arguments) {
 	return Qnil;
 }
 
-VALUE IO_Event_Selector_EPoll_io_read(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _length, VALUE _offset) {
-	size_t offset = NUM2SIZET(_offset);
-	size_t length = NUM2SIZET(_length);
-	
+VALUE IO_Event_Selector_EPoll_io_read(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _first, VALUE _second) {
 	void *base;
 	size_t size;
 	rb_io_buffer_get_bytes_for_writing(buffer, &base, &size);
+	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	size_t offset = NUM2SIZET(_first);
+	size_t length = NUM2SIZET(_second);
+	
+	if (!IO_Event_Selector_valid_buffer_range(size, offset, length)) {
+		return rb_fiber_scheduler_io_result(-1, EINVAL);
+	} else if (length == 0) {
+		return rb_fiber_scheduler_io_result(0, 0);
+	}
+	
+	base = (char*)base + offset;
+	size = length;
+#else
+	size_t length = NUM2SIZET(_first);
+	size_t offset = NUM2SIZET(_second);
 	
 	if (offset > size) {
 		return rb_fiber_scheduler_io_result(-1, EINVAL);
@@ -662,19 +684,24 @@ VALUE IO_Event_Selector_EPoll_io_read(VALUE self, VALUE fiber, VALUE io, VALUE b
 	
 	base = (char*)base + offset;
 	size -= offset;
+#endif
 	
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	
 	struct io_read_arguments io_read_arguments = {
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 		.self = self,
 		.fiber = fiber,
 		.io = io,
+#endif
 		
 		.flags = IO_Event_Selector_nonblock_set(descriptor),
 		.descriptor = descriptor,
 		.base = base,
 		.size = size,
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 		.length = length,
+#endif
 	};
 	
 	RB_OBJ_WRITTEN(self, Qundef, fiber);
@@ -682,6 +709,7 @@ VALUE IO_Event_Selector_EPoll_io_read(VALUE self, VALUE fiber, VALUE io, VALUE b
 	return rb_ensure(io_read_loop, (VALUE)&io_read_arguments, io_read_ensure, (VALUE)&io_read_arguments);
 }
 
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 VALUE IO_Event_Selector_EPoll_io_read_compatible(int argc, VALUE *argv, VALUE self)
 {
 	rb_check_arity(argc, 4, 5);
@@ -694,11 +722,14 @@ VALUE IO_Event_Selector_EPoll_io_read_compatible(int argc, VALUE *argv, VALUE se
 	
 	return IO_Event_Selector_EPoll_io_read(self, argv[0], argv[1], argv[2], argv[3], _offset);
 }
+#endif
 
 struct io_write_arguments {
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 	VALUE self;
 	VALUE fiber;
 	VALUE io;
+#endif
 	
 	int flags;
 	
@@ -708,14 +739,20 @@ struct io_write_arguments {
 	const void *base;
 	size_t size;
 	
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 	// The minimum number of bytes requested by the caller.
 	size_t length;
+#endif
 };
 
 static
 VALUE io_write_loop(VALUE _arguments) {
 	struct io_write_arguments *arguments = (struct io_write_arguments *)_arguments;
 	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	ssize_t result = write(arguments->descriptor, arguments->base, arguments->size);
+	return rb_fiber_scheduler_io_result(result, errno);
+#else
 	size_t length = arguments->length;
 	size_t total = 0;
 	
@@ -738,6 +775,7 @@ VALUE io_write_loop(VALUE _arguments) {
 	}
 	
 	return rb_fiber_scheduler_io_result(total, 0);
+#endif
 };
 
 static
@@ -749,13 +787,26 @@ VALUE io_write_ensure(VALUE _arguments) {
 	return Qnil;
 };
 
-VALUE IO_Event_Selector_EPoll_io_write(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _length, VALUE _offset) {
-	size_t length = NUM2SIZET(_length);
-	size_t offset = NUM2SIZET(_offset);
-	
+VALUE IO_Event_Selector_EPoll_io_write(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _first, VALUE _second) {
 	const void *base;
 	size_t size;
 	rb_io_buffer_get_bytes_for_reading(buffer, &base, &size);
+	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	size_t offset = NUM2SIZET(_first);
+	size_t length = NUM2SIZET(_second);
+	
+	if (!IO_Event_Selector_valid_buffer_range(size, offset, length)) {
+		return rb_fiber_scheduler_io_result(-1, EINVAL);
+	} else if (length == 0) {
+		return rb_fiber_scheduler_io_result(0, 0);
+	}
+	
+	base = (const char*)base + offset;
+	size = length;
+#else
+	size_t length = NUM2SIZET(_first);
+	size_t offset = NUM2SIZET(_second);
 	
 	if (length > size) {
 		rb_raise(rb_eRuntimeError, "Length exceeds size of buffer!");
@@ -769,19 +820,24 @@ VALUE IO_Event_Selector_EPoll_io_write(VALUE self, VALUE fiber, VALUE io, VALUE 
 	
 	base = (const char*)base + offset;
 	size -= offset;
+#endif
 	
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	
 	struct io_write_arguments io_write_arguments = {
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 		.self = self,
 		.fiber = fiber,
 		.io = io,
+#endif
 		
 		.flags = IO_Event_Selector_nonblock_set(descriptor),
 		.descriptor = descriptor,
 		.base = base,
 		.size = size,
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 		.length = length,
+#endif
 	};
 	
 	RB_OBJ_WRITTEN(self, Qundef, fiber);
@@ -789,6 +845,7 @@ VALUE IO_Event_Selector_EPoll_io_write(VALUE self, VALUE fiber, VALUE io, VALUE 
 	return rb_ensure(io_write_loop, (VALUE)&io_write_arguments, io_write_ensure, (VALUE)&io_write_arguments);
 }
 
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 VALUE IO_Event_Selector_EPoll_io_write_compatible(int argc, VALUE *argv, VALUE self)
 {
 	rb_check_arity(argc, 4, 5);
@@ -801,6 +858,7 @@ VALUE IO_Event_Selector_EPoll_io_write_compatible(int argc, VALUE *argv, VALUE s
 	
 	return IO_Event_Selector_EPoll_io_write(self, argv[0], argv[1], argv[2], argv[3], _offset);
 }
+#endif
 
 #endif
 
@@ -1123,13 +1181,14 @@ void Init_IO_Event_Selector_EPoll(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_EPoll, "io_wait", IO_Event_Selector_EPoll_io_wait, 3);
 	
 #ifdef HAVE_RUBY_IO_BUFFER_H
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	rb_define_method(IO_Event_Selector_EPoll, "io_read", IO_Event_Selector_EPoll_io_read, 5);
+	rb_define_method(IO_Event_Selector_EPoll, "io_write", IO_Event_Selector_EPoll_io_write, 5);
+#else
 	rb_define_method(IO_Event_Selector_EPoll, "io_read", IO_Event_Selector_EPoll_io_read_compatible, -1);
 	rb_define_method(IO_Event_Selector_EPoll, "io_write", IO_Event_Selector_EPoll_io_write_compatible, -1);
 #endif
-	
-	// Once compatibility isn't a concern, we can do this:
-	// rb_define_method(IO_Event_Selector_EPoll, "io_read", IO_Event_Selector_EPoll_io_read, 5);
-	// rb_define_method(IO_Event_Selector_EPoll, "io_write", IO_Event_Selector_EPoll_io_write, 5);
+#endif
 	
 	rb_define_method(IO_Event_Selector_EPoll, "process_wait", IO_Event_Selector_EPoll_process_wait, 3);
 }

--- a/ext/io/event/selector/kqueue.c
+++ b/ext/io/event/selector/kqueue.c
@@ -582,9 +582,11 @@ VALUE IO_Event_Selector_KQueue_io_wait(VALUE self, VALUE fiber, VALUE io, VALUE 
 #ifdef HAVE_RUBY_IO_BUFFER_H
 
 struct io_read_arguments {
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 	VALUE self;
 	VALUE fiber;
 	VALUE io;
+#endif
 	
 	int flags;
 	
@@ -594,14 +596,20 @@ struct io_read_arguments {
 	void *base;
 	size_t size;
 	
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 	// The minimum number of bytes requested by the caller.
 	size_t length;
+#endif
 };
 
 static
 VALUE io_read_loop(VALUE _arguments) {
 	struct io_read_arguments *arguments = (struct io_read_arguments *)_arguments;
 	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	ssize_t result = read(arguments->descriptor, arguments->base, arguments->size);
+	return rb_fiber_scheduler_io_result(result, errno);
+#else
 	size_t length = arguments->length;
 	size_t total = 0;
 	
@@ -631,6 +639,7 @@ VALUE io_read_loop(VALUE _arguments) {
 	
 	if (DEBUG_IO_READ) fprintf(stderr, "io_read_loop(fd=%d, length=%zu) -> %zu\n", arguments->descriptor, length, total);
 	return rb_fiber_scheduler_io_result(total, 0);
+#endif
 }
 
 static
@@ -642,16 +651,29 @@ VALUE io_read_ensure(VALUE _arguments) {
 	return Qnil;
 }
 
-VALUE IO_Event_Selector_KQueue_io_read(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _length, VALUE _offset) {
+VALUE IO_Event_Selector_KQueue_io_read(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _first, VALUE _second) {
 	struct IO_Event_Selector_KQueue *selector = NULL;
 	TypedData_Get_Struct(self, struct IO_Event_Selector_KQueue, &IO_Event_Selector_KQueue_Type, selector);
-	
-	size_t length = NUM2SIZET(_length);
-	size_t offset = NUM2SIZET(_offset);
 	
 	void *base;
 	size_t size;
 	rb_io_buffer_get_bytes_for_writing(buffer, &base, &size);
+	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	size_t offset = NUM2SIZET(_first);
+	size_t length = NUM2SIZET(_second);
+	
+	if (!IO_Event_Selector_valid_buffer_range(size, offset, length)) {
+		return rb_fiber_scheduler_io_result(-1, EINVAL);
+	} else if (length == 0) {
+		return rb_fiber_scheduler_io_result(0, 0);
+	}
+	
+	base = (char*)base + offset;
+	size = length;
+#else
+	size_t length = NUM2SIZET(_first);
+	size_t offset = NUM2SIZET(_second);
 	
 	if (offset > size) {
 		return rb_fiber_scheduler_io_result(-1, EINVAL);
@@ -661,19 +683,24 @@ VALUE IO_Event_Selector_KQueue_io_read(VALUE self, VALUE fiber, VALUE io, VALUE 
 	
 	base = (char*)base + offset;
 	size -= offset;
+#endif
 	
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	
 	struct io_read_arguments io_read_arguments = {
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 		.self = self,
 		.fiber = fiber,
 		.io = io,
+#endif
 		
 		.flags = IO_Event_Selector_nonblock_set(descriptor),
 		.descriptor = descriptor,
 		.base = base,
 		.size = size,
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 		.length = length,
+#endif
 	};
 	
 	RB_OBJ_WRITTEN(self, Qundef, fiber);
@@ -681,6 +708,7 @@ VALUE IO_Event_Selector_KQueue_io_read(VALUE self, VALUE fiber, VALUE io, VALUE 
 	return rb_ensure(io_read_loop, (VALUE)&io_read_arguments, io_read_ensure, (VALUE)&io_read_arguments);
 }
 
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 static VALUE IO_Event_Selector_KQueue_io_read_compatible(int argc, VALUE *argv, VALUE self)
 {
 	rb_check_arity(argc, 4, 5);
@@ -693,11 +721,14 @@ static VALUE IO_Event_Selector_KQueue_io_read_compatible(int argc, VALUE *argv, 
 	
 	return IO_Event_Selector_KQueue_io_read(self, argv[0], argv[1], argv[2], argv[3], _offset);
 }
+#endif
 
 struct io_write_arguments {
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 	VALUE self;
 	VALUE fiber;
 	VALUE io;
+#endif
 	
 	int flags;
 	
@@ -707,14 +738,20 @@ struct io_write_arguments {
 	const void *base;
 	size_t size;
 	
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 	// The minimum number of bytes requested by the caller.
 	size_t length;
+#endif
 };
 
 static
 VALUE io_write_loop(VALUE _arguments) {
 	struct io_write_arguments *arguments = (struct io_write_arguments *)_arguments;
 	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	ssize_t result = write(arguments->descriptor, arguments->base, arguments->size);
+	return rb_fiber_scheduler_io_result(result, errno);
+#else
 	size_t length = arguments->length;
 	size_t total = 0;
 	
@@ -744,6 +781,7 @@ VALUE io_write_loop(VALUE _arguments) {
 	
 	if (DEBUG_IO_WRITE) fprintf(stderr, "io_write_loop(fd=%d, length=%zu) -> %zu\n", arguments->descriptor, length, total);
 	return rb_fiber_scheduler_io_result(total, 0);
+#endif
 };
 
 static
@@ -755,16 +793,29 @@ VALUE io_write_ensure(VALUE _arguments) {
 	return Qnil;
 };
 
-VALUE IO_Event_Selector_KQueue_io_write(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _length, VALUE _offset) {
+VALUE IO_Event_Selector_KQueue_io_write(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _first, VALUE _second) {
 	struct IO_Event_Selector_KQueue *selector = NULL;
 	TypedData_Get_Struct(self, struct IO_Event_Selector_KQueue, &IO_Event_Selector_KQueue_Type, selector);
-	
-	size_t length = NUM2SIZET(_length);
-	size_t offset = NUM2SIZET(_offset);
 	
 	const void *base;
 	size_t size;
 	rb_io_buffer_get_bytes_for_reading(buffer, &base, &size);
+	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	size_t offset = NUM2SIZET(_first);
+	size_t length = NUM2SIZET(_second);
+	
+	if (!IO_Event_Selector_valid_buffer_range(size, offset, length)) {
+		return rb_fiber_scheduler_io_result(-1, EINVAL);
+	} else if (length == 0) {
+		return rb_fiber_scheduler_io_result(0, 0);
+	}
+	
+	base = (const char*)base + offset;
+	size = length;
+#else
+	size_t length = NUM2SIZET(_first);
+	size_t offset = NUM2SIZET(_second);
 	
 	if (length > size) {
 		rb_raise(rb_eRuntimeError, "Length exceeds size of buffer!");
@@ -778,19 +829,24 @@ VALUE IO_Event_Selector_KQueue_io_write(VALUE self, VALUE fiber, VALUE io, VALUE
 	
 	base = (const char*)base + offset;
 	size -= offset;
+#endif
 	
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	
 	struct io_write_arguments io_write_arguments = {
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 		.self = self,
 		.fiber = fiber,
 		.io = io,
+#endif
 		
 		.flags = IO_Event_Selector_nonblock_set(descriptor),
 		.descriptor = descriptor,
 		.base = base,
 		.size = size,
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 		.length = length,
+#endif
 	};
 	
 	RB_OBJ_WRITTEN(self, Qundef, fiber);
@@ -798,6 +854,7 @@ VALUE IO_Event_Selector_KQueue_io_write(VALUE self, VALUE fiber, VALUE io, VALUE
 	return rb_ensure(io_write_loop, (VALUE)&io_write_arguments, io_write_ensure, (VALUE)&io_write_arguments);
 }
 
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 static VALUE IO_Event_Selector_KQueue_io_write_compatible(int argc, VALUE *argv, VALUE self)
 {
 	rb_check_arity(argc, 4, 5);
@@ -810,6 +867,7 @@ static VALUE IO_Event_Selector_KQueue_io_write_compatible(int argc, VALUE *argv,
 	
 	return IO_Event_Selector_KQueue_io_write(self, argv[0], argv[1], argv[2], argv[3], _offset);
 }
+#endif
 
 #endif
 
@@ -1125,8 +1183,13 @@ void Init_IO_Event_Selector_KQueue(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_KQueue, "io_wait", IO_Event_Selector_KQueue_io_wait, 3);
 	
 #ifdef HAVE_RUBY_IO_BUFFER_H
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	rb_define_method(IO_Event_Selector_KQueue, "io_read", IO_Event_Selector_KQueue_io_read, 5);
+	rb_define_method(IO_Event_Selector_KQueue, "io_write", IO_Event_Selector_KQueue_io_write, 5);
+#else
 	rb_define_method(IO_Event_Selector_KQueue, "io_read", IO_Event_Selector_KQueue_io_read_compatible, -1);
 	rb_define_method(IO_Event_Selector_KQueue, "io_write", IO_Event_Selector_KQueue_io_write_compatible, -1);
+#endif
 #endif
 	
 	rb_define_method(IO_Event_Selector_KQueue, "process_wait", IO_Event_Selector_KQueue_process_wait, 3);

--- a/ext/io/event/selector/selector.h
+++ b/ext/io/event/selector/selector.h
@@ -40,6 +40,10 @@ static inline int IO_Event_try_again(int error) {
 	return error == EAGAIN || error == EWOULDBLOCK;
 }
 
+static inline int IO_Event_Selector_valid_buffer_range(size_t size, size_t offset, size_t length) {
+	return offset <= size && length <= size - offset;
+}
+
 // Enter a blocking region without the GVL. On Rubies without
 // `RB_NOGVL_PENDING_INTR_FAIL`, refresh pending-interrupt state immediately
 // before releasing the GVL so a signal cannot be stranded in the queue.

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -876,7 +876,7 @@ io_read(struct IO_Event_Selector_URing *selector, VALUE fiber, int descriptor, c
 	);
 }
 
-VALUE IO_Event_Selector_URing_io_read(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _length, VALUE _offset) {
+VALUE IO_Event_Selector_URing_io_read(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _first, VALUE _second) {
 	struct IO_Event_Selector_URing *selector = NULL;
 	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, selector);
 	
@@ -884,8 +884,18 @@ VALUE IO_Event_Selector_URing_io_read(VALUE self, VALUE fiber, VALUE io, VALUE b
 	size_t size;
 	rb_io_buffer_get_bytes_for_writing(buffer, &base, &size);
 	
-	size_t length = NUM2SIZET(_length);
-	size_t offset = NUM2SIZET(_offset);
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	size_t offset = NUM2SIZET(_first);
+	size_t length = NUM2SIZET(_second);
+	
+	if (!IO_Event_Selector_valid_buffer_range(size, offset, length)) {
+		return rb_fiber_scheduler_io_result(-1, EINVAL);
+	} else if (length == 0) {
+		return rb_fiber_scheduler_io_result(0, 0);
+	}
+#else
+	size_t length = NUM2SIZET(_first);
+	size_t offset = NUM2SIZET(_second);
 	size_t total = 0;
 	
 	// Ensure offset is within the bounds of the buffer to avoid size_t underflow and out-of-bounds pointer arithmetic on (char *)base + offset.
@@ -894,10 +904,19 @@ VALUE IO_Event_Selector_URing_io_read(VALUE self, VALUE fiber, VALUE io, VALUE b
 	} else if (offset == size) {
 		return rb_fiber_scheduler_io_result(0, 0);
 	}
+#endif
 	
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	off_t from = io_seekable(descriptor);
 	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	int result = io_read(selector, fiber, descriptor, (char*)base + offset, length, from);
+	if (result < 0) {
+		return rb_fiber_scheduler_io_result(-1, -result);
+	}
+	
+	return rb_fiber_scheduler_io_result(result, 0);
+#else
 	size_t maximum_size = size - offset;
 	
 	// Are we performing a non-blocking read?
@@ -933,8 +952,10 @@ VALUE IO_Event_Selector_URing_io_read(VALUE self, VALUE fiber, VALUE io, VALUE b
 	}
 	
 	return rb_fiber_scheduler_io_result(total, 0);
+#endif
 }
 
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 static VALUE IO_Event_Selector_URing_io_read_compatible(int argc, VALUE *argv, VALUE self)
 {
 	rb_check_arity(argc, 4, 5);
@@ -947,8 +968,9 @@ static VALUE IO_Event_Selector_URing_io_read_compatible(int argc, VALUE *argv, V
 	
 	return IO_Event_Selector_URing_io_read(self, argv[0], argv[1], argv[2], argv[3], _offset);
 }
+#endif
 
-VALUE IO_Event_Selector_URing_io_pread(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _from, VALUE _length, VALUE _offset) {
+VALUE IO_Event_Selector_URing_io_pread(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _from, VALUE _first, VALUE _second) {
 	struct IO_Event_Selector_URing *selector = NULL;
 	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, selector);
 	
@@ -956,10 +978,19 @@ VALUE IO_Event_Selector_URing_io_pread(VALUE self, VALUE fiber, VALUE io, VALUE 
 	size_t size;
 	rb_io_buffer_get_bytes_for_writing(buffer, &base, &size);
 	
-	size_t length = NUM2SIZET(_length);
-	size_t offset = NUM2SIZET(_offset);
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	size_t offset = NUM2SIZET(_first);
+	size_t length = NUM2SIZET(_second);
+	
+	if (!IO_Event_Selector_valid_buffer_range(size, offset, length)) {
+		return rb_fiber_scheduler_io_result(-1, EINVAL);
+	} else if (length == 0) {
+		return rb_fiber_scheduler_io_result(0, 0);
+	}
+#else
+	size_t length = NUM2SIZET(_first);
+	size_t offset = NUM2SIZET(_second);
 	size_t total = 0;
-	off_t from = NUM2OFFT(_from);
 	
 	// Ensure offset is within the bounds of the buffer to avoid size_t underflow and out-of-bounds pointer arithmetic on (char *)base + offset.
 	if (offset > size) {
@@ -967,9 +998,19 @@ VALUE IO_Event_Selector_URing_io_pread(VALUE self, VALUE fiber, VALUE io, VALUE 
 	} else if (offset == size) {
 		return rb_fiber_scheduler_io_result(0, 0);
 	}
+#endif
+	off_t from = NUM2OFFT(_from);
 	
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	int result = io_read(selector, fiber, descriptor, (char*)base + offset, length, from);
+	if (result < 0) {
+		return rb_fiber_scheduler_io_result(-1, -result);
+	}
+	
+	return rb_fiber_scheduler_io_result(result, 0);
+#else
 	size_t maximum_size = size - offset;
 	while (maximum_size) {
 		int result = io_read(selector, fiber, descriptor, (char*)base+offset, maximum_size, from);
@@ -992,6 +1033,7 @@ VALUE IO_Event_Selector_URing_io_pread(VALUE self, VALUE fiber, VALUE io, VALUE 
 	}
 	
 	return rb_fiber_scheduler_io_result(total, 0);
+#endif
 }
 
 #pragma mark - IO#write
@@ -1068,7 +1110,7 @@ io_write(struct IO_Event_Selector_URing *selector, VALUE fiber, int descriptor, 
 	);
 }
 
-VALUE IO_Event_Selector_URing_io_write(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _length, VALUE _offset) {
+VALUE IO_Event_Selector_URing_io_write(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _first, VALUE _second) {
 	struct IO_Event_Selector_URing *selector = NULL;
 	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, selector);
 	
@@ -1076,8 +1118,18 @@ VALUE IO_Event_Selector_URing_io_write(VALUE self, VALUE fiber, VALUE io, VALUE 
 	size_t size;
 	rb_io_buffer_get_bytes_for_reading(buffer, &base, &size);
 	
-	size_t length = NUM2SIZET(_length);
-	size_t offset = NUM2SIZET(_offset);
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	size_t offset = NUM2SIZET(_first);
+	size_t length = NUM2SIZET(_second);
+	
+	if (!IO_Event_Selector_valid_buffer_range(size, offset, length)) {
+		return rb_fiber_scheduler_io_result(-1, EINVAL);
+	} else if (length == 0) {
+		return rb_fiber_scheduler_io_result(0, 0);
+	}
+#else
+	size_t length = NUM2SIZET(_first);
+	size_t offset = NUM2SIZET(_second);
 	size_t total = 0;
 	
 	if (length > size) {
@@ -1090,10 +1142,19 @@ VALUE IO_Event_Selector_URing_io_write(VALUE self, VALUE fiber, VALUE io, VALUE 
 	} else if (offset == size) {
 		return rb_fiber_scheduler_io_result(0, 0);
 	}
+#endif
 	
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	off_t from = io_seekable(descriptor);
 	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	int result = io_write(selector, fiber, descriptor, (char*)base + offset, length, from);
+	if (result < 0) {
+		return rb_fiber_scheduler_io_result(-1, -result);
+	}
+	
+	return rb_fiber_scheduler_io_result(result, 0);
+#else
 	size_t maximum_size = size - offset;
 	while (maximum_size) {
 		int result = io_write(selector, fiber, descriptor, (char*)base+offset, maximum_size, from);
@@ -1115,8 +1176,10 @@ VALUE IO_Event_Selector_URing_io_write(VALUE self, VALUE fiber, VALUE io, VALUE 
 	}
 	
 	return rb_fiber_scheduler_io_result(total, 0);
+#endif
 }
 
+#if RUBY_FIBER_SCHEDULER_VERSION < 4
 static VALUE IO_Event_Selector_URing_io_write_compatible(int argc, VALUE *argv, VALUE self)
 {
 	rb_check_arity(argc, 4, 5);
@@ -1129,8 +1192,9 @@ static VALUE IO_Event_Selector_URing_io_write_compatible(int argc, VALUE *argv, 
 	
 	return IO_Event_Selector_URing_io_write(self, argv[0], argv[1], argv[2], argv[3], _offset);
 }
+#endif
 
-VALUE IO_Event_Selector_URing_io_pwrite(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _from, VALUE _length, VALUE _offset) {
+VALUE IO_Event_Selector_URing_io_pwrite(VALUE self, VALUE fiber, VALUE io, VALUE buffer, VALUE _from, VALUE _first, VALUE _second) {
 	struct IO_Event_Selector_URing *selector = NULL;
 	TypedData_Get_Struct(self, struct IO_Event_Selector_URing, &IO_Event_Selector_URing_Type, selector);
 	
@@ -1138,10 +1202,19 @@ VALUE IO_Event_Selector_URing_io_pwrite(VALUE self, VALUE fiber, VALUE io, VALUE
 	size_t size;
 	rb_io_buffer_get_bytes_for_reading(buffer, &base, &size);
 	
-	size_t length = NUM2SIZET(_length);
-	size_t offset = NUM2SIZET(_offset);
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	size_t offset = NUM2SIZET(_first);
+	size_t length = NUM2SIZET(_second);
+	
+	if (!IO_Event_Selector_valid_buffer_range(size, offset, length)) {
+		return rb_fiber_scheduler_io_result(-1, EINVAL);
+	} else if (length == 0) {
+		return rb_fiber_scheduler_io_result(0, 0);
+	}
+#else
+	size_t length = NUM2SIZET(_first);
+	size_t offset = NUM2SIZET(_second);
 	size_t total = 0;
-	off_t from = NUM2OFFT(_from);
 	
 	if (length > size) {
 		rb_raise(rb_eRuntimeError, "Length exceeds size of buffer!");
@@ -1153,9 +1226,19 @@ VALUE IO_Event_Selector_URing_io_pwrite(VALUE self, VALUE fiber, VALUE io, VALUE
 	} else if (offset == size) {
 		return rb_fiber_scheduler_io_result(0, 0);
 	}
+#endif
+	off_t from = NUM2OFFT(_from);
 	
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	int result = io_write(selector, fiber, descriptor, (char*)base + offset, length, from);
+	if (result < 0) {
+		return rb_fiber_scheduler_io_result(-1, -result);
+	}
+	
+	return rb_fiber_scheduler_io_result(result, 0);
+#else
 	size_t maximum_size = size - offset;
 	while (maximum_size) {
 		int result = io_write(selector, fiber, descriptor, (char*)base+offset, maximum_size, from);
@@ -1178,6 +1261,7 @@ VALUE IO_Event_Selector_URing_io_pwrite(VALUE self, VALUE fiber, VALUE io, VALUE
 	}
 	
 	return rb_fiber_scheduler_io_result(total, 0);
+#endif
 }
 
 #endif
@@ -1511,8 +1595,13 @@ void Init_IO_Event_Selector_URing(VALUE IO_Event_Selector) {
 	rb_define_method(IO_Event_Selector_URing, "io_wait", IO_Event_Selector_URing_io_wait, 3);
 	
 #ifdef HAVE_RUBY_IO_BUFFER_H
+#if RUBY_FIBER_SCHEDULER_VERSION >= 4
+	rb_define_method(IO_Event_Selector_URing, "io_read", IO_Event_Selector_URing_io_read, 5);
+	rb_define_method(IO_Event_Selector_URing, "io_write", IO_Event_Selector_URing_io_write, 5);
+#else
 	rb_define_method(IO_Event_Selector_URing, "io_read", IO_Event_Selector_URing_io_read_compatible, -1);
 	rb_define_method(IO_Event_Selector_URing, "io_write", IO_Event_Selector_URing_io_write_compatible, -1);
+#endif
 	rb_define_method(IO_Event_Selector_URing, "io_pread", IO_Event_Selector_URing_io_pread, 6);
 	rb_define_method(IO_Event_Selector_URing, "io_pwrite", IO_Event_Selector_URing_io_pwrite, 6);
 #endif

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -33,21 +33,21 @@ input, output = IO.pipe
 
 writer = Fiber.new do
 	puts "[writer] Writing data"
-
+	
 	output.write("Hello World")
 	output.close
 end
 
 reader = Fiber.new do
 	puts "[reader] No data available, waiting for input"
-
+	
 	# Suspend this Fiber until the input becomes readable.
 	selector.io_wait(
 		Fiber.current,
 		input,
 		IO::READABLE
 	)
-
+	
 	# Execution resumes here once the selector detects the event.
 	puts "[reader] Received: #{input.read.inspect}"
 end

--- a/lib/io/event/debug/selector.rb
+++ b/lib/io/event/debug/selector.rb
@@ -177,15 +177,15 @@ module IO::Event
 			end
 			
 			# Read from the given IO, forwarded to the underlying selector.
-			def io_read(fiber, io, buffer, length, offset = 0)
-				log("Reading from IO #{io.inspect} with buffer #{buffer}; length #{length} offset #{offset}")
-				@selector.io_read(fiber, io, buffer, length, offset)
+			def io_read(fiber, io, buffer, *arguments)
+				log("Reading from IO #{io.inspect} with buffer #{buffer}; arguments #{arguments.inspect}")
+				@selector.io_read(fiber, io, buffer, *arguments)
 			end
 			
 			# Write to the given IO, forwarded to the underlying selector.
-			def io_write(fiber, io, buffer, length, offset = 0)
-				log("Writing to IO #{io.inspect} with buffer #{buffer}; length #{length} offset #{offset}")
-				@selector.io_write(fiber, io, buffer, length, offset)
+			def io_write(fiber, io, buffer, *arguments)
+				log("Writing to IO #{io.inspect} with buffer #{buffer}; arguments #{arguments.inspect}")
+				@selector.io_write(fiber, io, buffer, *arguments)
 			end
 			
 			# Forward the given method to the underlying selector.

--- a/lib/io/event/selector/select.rb
+++ b/lib/io/event/selector/select.rb
@@ -197,78 +197,112 @@ module IO::Event
 				errno == EAGAIN or errno == EWOULDBLOCK
 			end
 			
-			# Read from the given IO to the buffer.
-			#
-			# @parameter length [Integer] The minimum number of bytes to read.
-			# @parameter offset [Integer] The offset into the buffer to read to.
-			def io_read(fiber, io, buffer, length, offset = 0)
-				# Ensure offset is within the bounds of the buffer to avoid ArgumentError
-				if offset > buffer.size
-					return -Errno::EINVAL::Errno
-				elsif offset == buffer.size
-					return 0
-				end
-				
-				total = 0
-				
-				Selector.nonblock(io) do
-					while true
-						result = Fiber.blocking{buffer.read(io, 0, offset)}
-						
-						if result < 0
-							if length > 0 and again?(result)
-								self.io_wait(fiber, io, IO::READABLE)
-							else
-								return result
-							end
-						elsif result == 0
-							break
-						else
-							total += result
-							break if total >= length
-							offset += result
-						end
+			if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+				# Read at most `length` bytes from the given IO to the buffer in one operation.
+				#
+				# @parameter offset [Integer] The offset into the buffer to read to.
+				# @parameter length [Integer] The maximum number of bytes to read.
+				def io_read(fiber, io, buffer, offset, length)
+					if offset > buffer.size || length > buffer.size - offset
+						return -Errno::EINVAL::Errno
+					elsif length == 0
+						return 0
+					end
+					
+					Selector.nonblock(io) do
+						return Fiber.blocking{buffer.read(io, offset, length)}
 					end
 				end
 				
-				return total
-			end
-			
-			# Write to the given IO from the buffer.
-			#
-			# @parameter length [Integer] The minimum number of bytes to write.
-			# @parameter offset [Integer] The offset into the buffer to write from.
-			def io_write(fiber, io, buffer, length, offset = 0)
-				# Ensure offset is within the bounds of the buffer to avoid ArgumentError
-				if offset > buffer.size
-					return -Errno::EINVAL::Errno
-				elsif offset == buffer.size
-					return 0
-				end
-				
-				total = 0
-				
-				Selector.nonblock(io) do
-					while true
-						result = Fiber.blocking{buffer.write(io, 0, offset)}
-						
-						if result < 0
-							if length > 0 and again?(result)
-								self.io_wait(fiber, io, IO::WRITABLE)
-							else
-								return result
-							end
-						elsif result == 0
-							break result
-						else
-							total += result
-							break if total >= length
-							offset += result
-						end
+				# Write at most `length` bytes to the given IO from the buffer in one operation.
+				#
+				# @parameter offset [Integer] The offset into the buffer to write from.
+				# @parameter length [Integer] The maximum number of bytes to write.
+				def io_write(fiber, io, buffer, offset, length)
+					if offset > buffer.size || length > buffer.size - offset
+						return -Errno::EINVAL::Errno
+					elsif length == 0
+						return 0
+					end
+					
+					Selector.nonblock(io) do
+						return Fiber.blocking{buffer.write(io, offset, length)}
 					end
 				end
+			else
+				# Read from the given IO to the buffer.
+				#
+				# @parameter length [Integer] The minimum number of bytes to read.
+				# @parameter offset [Integer] The offset into the buffer to read to.
+				def io_read(fiber, io, buffer, length, offset = 0)
+					# Ensure offset is within the bounds of the buffer to avoid `ArgumentError`:
+					if offset > buffer.size
+						return -Errno::EINVAL::Errno
+					elsif offset == buffer.size
+						return 0
+					end
+					
+					total = 0
+					
+					Selector.nonblock(io) do
+						while true
+							result = Fiber.blocking{buffer.read(io, 0, offset)}
+							
+							if result < 0
+								if length > 0 and again?(result)
+									self.io_wait(fiber, io, IO::READABLE)
+								else
+									return result
+								end
+							elsif result == 0
+								break
+							else
+								total += result
+								break if total >= length
+								offset += result
+							end
+						end
+					end
+					
+					return total
+				end
 				
-				return total
+				# Write to the given IO from the buffer.
+				#
+				# @parameter length [Integer] The minimum number of bytes to write.
+				# @parameter offset [Integer] The offset into the buffer to write from.
+				def io_write(fiber, io, buffer, length, offset = 0)
+					# Ensure offset is within the bounds of the buffer to avoid `ArgumentError`:
+					if offset > buffer.size
+						return -Errno::EINVAL::Errno
+					elsif offset == buffer.size
+						return 0
+					end
+					
+					total = 0
+					
+					Selector.nonblock(io) do
+						while true
+							result = Fiber.blocking{buffer.write(io, 0, offset)}
+							
+							if result < 0
+								if length > 0 and again?(result)
+									self.io_wait(fiber, io, IO::WRITABLE)
+								else
+									return result
+								end
+							elsif result == 0
+								break result
+							else
+								total += result
+								break if total >= length
+								offset += result
+							end
+						end
+					end
+					
+					return total
+				end
 			end
 			
 			# Wait for a process to change state.

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Add compatibility with Ruby 4.1's fiber scheduler interface version 4. Buffered IO operations now use `(offset, length)`, perform a single transfer of at most `length` bytes, return short transfers directly, and report `-EAGAIN` without waiting. Earlier Ruby versions retain the existing minimum-progress behavior.
+
 ## v1.19.5
 
   - Preserve the original exception or non-local control flow when `IO::Event::WorkerPool` cancellation interrupts a blocked fiber, while still cancelling and draining the in-flight blocking operation before returning control to Ruby.

--- a/test/io/event/debug/selector.rb
+++ b/test/io/event/debug/selector.rb
@@ -78,13 +78,13 @@ class FakeSelector
 		:calls_io_wait
 	end
 	
-	def io_read(fiber, io, buffer, length, offset = 0)
-		@calls << [:io_read, fiber, io, buffer, length, offset]
+	def io_read(fiber, io, buffer, *arguments)
+		@calls << [:io_read, fiber, io, buffer, *arguments]
 		:calls_io_read
 	end
 	
-	def io_write(fiber, io, buffer, length, offset = 0)
-		@calls << [:io_write, fiber, io, buffer, length, offset]
+	def io_write(fiber, io, buffer, *arguments)
+		@calls << [:io_write, fiber, io, buffer, *arguments]
 		:calls_io_write
 	end
 	
@@ -144,8 +144,13 @@ describe IO::Event::Debug::Selector do
 		expect(selector.blocking_operation_wait(:operation)).to be == :calls_blocking_operation_wait
 		expect(selector.process_wait(123, 0)).to be == :calls_process_wait
 		expect(selector.io_wait(fiber, input, IO::READABLE)).to be == :calls_io_wait
-		expect(selector.io_read(fiber, input, buffer, 1)).to be == :calls_io_read
-		expect(selector.io_write(fiber, output, buffer, 1)).to be == :calls_io_write
+		if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			expect(selector.io_read(fiber, input, buffer, 0, 1)).to be == :calls_io_read
+			expect(selector.io_write(fiber, output, buffer, 0, 1)).to be == :calls_io_write
+		else
+			expect(selector.io_read(fiber, input, buffer, 1)).to be == :calls_io_read
+			expect(selector.io_write(fiber, output, buffer, 1)).to be == :calls_io_write
+		end
 		expect(selector.io_close(input.fileno)).to be == :calls_io_close
 		expect(selector.respond_to?(:io_close)).to be == true
 		expect(selector.select(0)).to be == :calls_select

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -33,6 +33,22 @@ class FakeFiber
 end
 
 Selector = Sus::Shared("a selector") do
+	def io_read(io, buffer, offset, length)
+		if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			selector.io_read(Fiber.current, io, buffer, offset, length)
+		else
+			selector.io_read(Fiber.current, io, buffer, length, offset)
+		end
+	end
+	
+	def io_write(io, buffer, offset, length)
+		if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			selector.io_write(Fiber.current, io, buffer, offset, length)
+		else
+			selector.io_write(Fiber.current, io, buffer, length, offset)
+		end
+	end
+	
 	with "#select" do
 		let(:quantum) {0.2}
 		
@@ -503,52 +519,68 @@ Selector = Sus::Shared("a selector") do
 		it "can read a single message" do
 			return unless selector.respond_to?(:io_read)
 			
+			if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+				events << :write
+				remote.write(message)
+			end
+			
 			fiber = Fiber.new do
 				events << :io_read
-				offset = selector.io_read(Fiber.current, local, buffer, message.bytesize)
+				offset = io_read(local, buffer, 0, message.bytesize)
 				expect(buffer.get_string(0, offset)).to be == message
 			end
 			
 			fiber.transfer
 			
-			events << :write
-			remote.write(message)
+			if !defined?(IO::Buffer::VERSION) || IO::Buffer::VERSION < 3
+				events << :write
+				remote.write(message)
+				
+				selector.select(1)
+			end
 			
-			selector.select(1)
-			
-			expect(events).to be == [
-				:io_read, :write
-			]
+			if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+				expect(events).to be == [:write, :io_read]
+			else
+				expect(events).to be == [:io_read, :write]
+			end
 		end
 		
-		it "can handle partial reads" do
+		it "returns partial reads directly" do
 			return unless selector.respond_to?(:io_read)
 			
-			fiber = Fiber.new do
-				events << :io_read
-				offset = selector.io_read(Fiber.current, local, buffer, message.bytesize)
-				expect(buffer.get_string(0, offset)).to be == message
+			if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+				remote.write(message[0...5])
+				result = io_read(local, buffer, 0, message.bytesize)
+				
+				expect(result).to be == 5
+				expect(buffer.get_string(0, result)).to be == message[0...5]
+			else
+				fiber = Fiber.new do
+					events << :io_read
+					offset = io_read(local, buffer, 0, message.bytesize)
+					expect(buffer.get_string(0, offset)).to be == message
+				end
+				
+				fiber.transfer
+				
+				events << :write
+				remote.write(message[0...5])
+				selector.select(1)
+				remote.write(message[5...message.bytesize])
+				selector.select(1)
+				
+				expect(events).to be == [:io_read, :write]
 			end
-			
-			fiber.transfer
-			
-			events << :write
-			remote.write(message[0...5])
-			selector.select(1)
-			remote.write(message[5...message.bytesize])
-			selector.select(1)
-			
-			expect(events).to be == [
-				:io_read, :write
-			]
 		end
 		
 		it "can stop reading when reads are ready" do
 			# This could trigger a busy-loop in the KQueue selector.
 			return unless selector.respond_to?(:io_read)
+			skip "Single-transfer io_read does not wait for readiness" if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
 			
 			fiber = Fiber.new do
-				offset = selector.io_read(Fiber.current, local, buffer, message.bytesize)
+				offset = io_read(local, buffer, 0, message.bytesize)
 				expect(buffer.get_string(0, offset)).to be == message
 				sleep(0.001)
 			end
@@ -590,7 +622,7 @@ Selector = Sus::Shared("a selector") do
 			fiber = Fiber.new do
 				events << :io_write
 				buffer = IO::Buffer.for(message.dup)
-				result = selector.io_write(Fiber.current, local, buffer, buffer.size)
+				result = io_write(local, buffer, 0, buffer.size)
 				expect(result).to be == message.bytesize
 				local.close
 			end

--- a/test/io/event/selector/buffered_io.rb
+++ b/test/io/event/selector/buffered_io.rb
@@ -11,6 +11,22 @@ require "socket"
 require "unix_socket"
 
 BufferedIO = Sus::Shared("buffered io") do
+	def io_read(io, buffer, offset, length)
+		if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			selector.io_read(Fiber.current, io, buffer, offset, length)
+		else
+			selector.io_read(Fiber.current, io, buffer, length, offset)
+		end
+	end
+	
+	def io_write(io, buffer, offset, length)
+		if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			selector.io_write(Fiber.current, io, buffer, offset, length)
+		else
+			selector.io_write(Fiber.current, io, buffer, length, offset)
+		end
+	end
+	
 	with "a pipe" do
 		let(:pipe) {IO.pipe}
 		let(:input) {pipe.first}
@@ -21,25 +37,30 @@ BufferedIO = Sus::Shared("buffered io") do
 			
 			writer = Fiber.new do
 				buffer = IO::Buffer.new(128)
-				expect(selector.io_write(Fiber.current, output, buffer, 128, 0)).to be == 128
+				expect(io_write(output, buffer, 0, 128)).to be == 128
 			end
 			
 			reader = Fiber.new do
 				buffer = IO::Buffer.new(64)
-				expect(selector.io_read(Fiber.current, input, buffer, 1, 0)).to be == 64
+				expect(io_read(input, buffer, 0, 64)).to be == 64
 			end
 			
-			reader.transfer
-			writer.transfer
-			
-			expect(selector.select(1)).to be >= 1
+			if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+				writer.transfer
+				reader.transfer
+			else
+				reader.transfer
+				writer.transfer
+				
+				expect(selector.select(1)).to be >= 1
+			end
 		end
 		
 		it "can write zero length buffers" do
 			skip_if_ruby_platform(/mswin|mingw|cygwin/)
 			
 			buffer = IO::Buffer.new(1).slice(0, 0)
-			expect(selector.io_write(Fiber.current, output, buffer, 0, 0)).to be == 0
+			expect(io_write(output, buffer, 0, 0)).to be == 0
 		end
 		
 		it "can read and write at the specified offset" do
@@ -47,20 +68,42 @@ BufferedIO = Sus::Shared("buffered io") do
 			
 			writer = Fiber.new do
 				buffer = IO::Buffer.new(128)
-				# We can't write 128 bytes because there are only +64 bytes from offset 64.
-				expect(selector.io_write(Fiber.current, output, buffer, 128, 64)).to be == 64
+				expect(io_write(output, buffer, 64, 64)).to be == 64
 			end
 			
 			reader = Fiber.new do
 				buffer = IO::Buffer.new(128)
-				# Only 64 bytes are available to read.
-				expect(selector.io_read(Fiber.current, input, buffer, 1, 64)).to be == 64
+				expect(io_read(input, buffer, 64, 64)).to be == 64
 			end
 			
-			reader.transfer
-			writer.transfer
+			if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+				writer.transfer
+				reader.transfer
+			else
+				reader.transfer
+				writer.transfer
+				
+				expect(selector.select(1)).to be >= 1
+			end
+		end
+		
+		it "limits single-transfer reads to the requested range" do
+			skip "Requires IO::Buffer version 3" if !defined?(IO::Buffer::VERSION) || IO::Buffer::VERSION < 3
 			
-			expect(selector.select(1)).to be >= 1
+			output.write("abc")
+			buffer = IO::Buffer.new(8)
+			
+			expect(io_read(input, buffer, 2, 3)).to be == 3
+			expect(buffer.get_string(2, 3)).to be == "abc"
+		end
+		
+		it "limits single-transfer writes to the requested range" do
+			skip "Requires IO::Buffer version 3" if !defined?(IO::Buffer::VERSION) || IO::Buffer::VERSION < 3
+			
+			buffer = IO::Buffer.for("01234567".dup)
+			
+			expect(io_write(output, buffer, 2, 3)).to be == 3
+			expect(input.read(3)).to be == "234"
 		end
 		
 		it "can't write to the read end of a pipe" do
@@ -70,7 +113,7 @@ BufferedIO = Sus::Shared("buffered io") do
 			
 			writer = Fiber.new do
 				buffer = IO::Buffer.new(64)
-				result = selector.io_write(Fiber.current, input, buffer, 64, 0)
+				result = io_write(input, buffer, 0, 64)
 				expect(result).to be < 0
 			end
 			
@@ -88,7 +131,7 @@ BufferedIO = Sus::Shared("buffered io") do
 			output.close
 			
 			reader = Fiber.new do
-				result = selector.io_read(Fiber.current, input, buffer, 0, 0)
+				result = io_read(input, buffer, 0, 64)
 			end
 			
 			reader.transfer
@@ -109,7 +152,11 @@ BufferedIO = Sus::Shared("buffered io") do
 			result = nil
 			
 			reader = Fiber.new do
-				result = selector.io_read(Fiber.current, input, buffer, 0, 0)
+				if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+					result = io_read(input, buffer, 0, 64)
+				else
+					result = selector.io_read(Fiber.current, input, buffer, 0, 0)
+				end
 			end
 			
 			reader.transfer
@@ -125,7 +172,7 @@ BufferedIO = Sus::Shared("buffered io") do
 			
 			reader = Fiber.new do
 				# Offset 128 exceeds buffer size of 64
-				result = selector.io_read(Fiber.current, input, buffer, 1, 128)
+				result = io_read(input, buffer, 128, 1)
 				expect(result).to be == -Errno::EINVAL::Errno
 			end
 			
@@ -138,7 +185,7 @@ BufferedIO = Sus::Shared("buffered io") do
 			buffer = IO::Buffer.new(64)
 			
 			reader = Fiber.new do
-				result = selector.io_read(Fiber.current, input, buffer, 1, 64)
+				result = io_read(input, buffer, 64, 0)
 				expect(result).to be == 0
 			end
 			
@@ -153,7 +200,7 @@ BufferedIO = Sus::Shared("buffered io") do
 			
 			writer = Fiber.new do
 				# Offset 128 exceeds buffer size of 64
-				result = selector.io_write(Fiber.current, output, buffer, 1, 128)
+				result = io_write(output, buffer, 128, 1)
 				expect(result).to be == -Errno::EINVAL::Errno
 			end
 			
@@ -166,7 +213,7 @@ BufferedIO = Sus::Shared("buffered io") do
 			buffer = IO::Buffer.new(64)
 			
 			writer = Fiber.new do
-				result = selector.io_write(Fiber.current, output, buffer, 1, 64)
+				result = io_write(output, buffer, 64, 0)
 				expect(result).to be == 0
 			end
 			

--- a/test/io/event/selector/cancellable.rb
+++ b/test/io/event/selector/cancellable.rb
@@ -21,6 +21,8 @@ Cancellable = Sus::Shared("cancellable") do
 		end
 		
 		it "can cancel reads" do
+			skip "Single-transfer io_read does not wait for readiness" if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			
 			reader = Fiber.new do
 				buffer = IO::Buffer.new(64)
 				
@@ -39,6 +41,8 @@ Cancellable = Sus::Shared("cancellable") do
 		end
 		
 		it "can cancel waits" do
+			skip "Single-transfer io_read does not wait for readiness" if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			
 			reader = Fiber.new do
 				buffer = IO::Buffer.new(64)
 				

--- a/test/io/event/selector/file_io.rb
+++ b/test/io/event/selector/file_io.rb
@@ -8,6 +8,38 @@ require "io/event/selector"
 require "tempfile"
 
 FileIO = Sus::Shared("file io") do
+	def io_read(io, buffer, offset, length)
+		if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			selector.io_read(Fiber.current, io, buffer, offset, length)
+		else
+			selector.io_read(Fiber.current, io, buffer, length, offset)
+		end
+	end
+	
+	def io_write(io, buffer, offset, length)
+		if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			selector.io_write(Fiber.current, io, buffer, offset, length)
+		else
+			selector.io_write(Fiber.current, io, buffer, length, offset)
+		end
+	end
+	
+	def io_pread(io, buffer, from, offset, length)
+		if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			selector.io_pread(Fiber.current, io, buffer, from, offset, length)
+		else
+			selector.io_pread(Fiber.current, io, buffer, from, length, offset)
+		end
+	end
+	
+	def io_pwrite(io, buffer, from, offset, length)
+		if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			selector.io_pwrite(Fiber.current, io, buffer, from, offset, length)
+		else
+			selector.io_pwrite(Fiber.current, io, buffer, from, length, offset)
+		end
+	end
+	
 	with "a file" do
 		let(:file) {Tempfile.new}
 		
@@ -20,15 +52,14 @@ FileIO = Sus::Shared("file io") do
 			writer = Fiber.new do
 				buffer = IO::Buffer.new(128)
 				file.seek(0)
-				write_result = selector.io_write(Fiber.current, file, buffer, 128)
+				write_result = io_write(file, buffer, 0, 128)
 			end
 			
 			reader = Fiber.new do
 				buffer = IO::Buffer.new(64)
 				file.seek(0)
 				
-				# The read will return 0 if the data is not written yet:
-				read_result = selector.io_read(Fiber.current, file, buffer, 0)
+				read_result = io_read(file, buffer, 0, 64)
 			end
 			
 			writer.transfer
@@ -55,12 +86,12 @@ FileIO = Sus::Shared("file io") do
 			
 			writer = Fiber.new do
 				buffer = IO::Buffer.new(128)
-				write_result = selector.io_pwrite(Fiber.current, file, buffer, 0, 128, 0)
+				write_result = io_pwrite(file, buffer, 0, 0, 128)
 			end
 			
 			reader = Fiber.new do
 				buffer = IO::Buffer.new(64)
-				read_result = selector.io_pread(Fiber.current, file, buffer, 0, 64, 0)
+				read_result = io_pread(file, buffer, 0, 0, 64)
 			end
 			
 			writer.transfer
@@ -77,6 +108,18 @@ FileIO = Sus::Shared("file io") do
 			
 			expect(write_result).to be == 128
 			expect(read_result).to be == 64
+		end
+		
+		it "uses positional IO ranges" do
+			skip "Requires IO::Buffer version 3" if !defined?(IO::Buffer::VERSION) || IO::Buffer::VERSION < 3
+			skip "io_pread is not implemented" unless selector.respond_to?(:io_pread)
+			
+			write_buffer = IO::Buffer.for("01234567".dup)
+			expect(io_pwrite(file, write_buffer, 5, 2, 3)).to be == 3
+			
+			read_buffer = IO::Buffer.new(8)
+			expect(io_pread(file, read_buffer, 5, 1, 3)).to be == 3
+			expect(read_buffer.get_string(1, 3)).to be == "234"
 		end
 		
 		it "can wait for the file to become writable" do
@@ -100,7 +143,7 @@ FileIO = Sus::Shared("file io") do
 			file.seek(0)
 			
 			# Offset 128 exceeds buffer size of 64
-			result = selector.io_read(Fiber.current, file, buffer, 1, 128)
+			result = io_read(file, buffer, 128, 1)
 			
 			expect(result).to be == -Errno::EINVAL::Errno
 		end
@@ -112,7 +155,7 @@ FileIO = Sus::Shared("file io") do
 			file.seek(0)
 			
 			# Offset 128 exceeds buffer size of 64
-			result = selector.io_write(Fiber.current, file, buffer, 1, 128)
+			result = io_write(file, buffer, 128, 1)
 			
 			expect(result).to be == -Errno::EINVAL::Errno
 		end
@@ -123,7 +166,7 @@ FileIO = Sus::Shared("file io") do
 			buffer = IO::Buffer.new(64)
 			
 			# Offset 128 exceeds buffer size of 64
-			result = selector.io_pread(Fiber.current, file, buffer, 0, 1, 128)
+			result = io_pread(file, buffer, 0, 128, 1)
 			
 			expect(result).to be == -Errno::EINVAL::Errno
 		end
@@ -134,7 +177,7 @@ FileIO = Sus::Shared("file io") do
 			buffer = IO::Buffer.new(64)
 			
 			# Offset 128 exceeds buffer size of 64
-			result = selector.io_pwrite(Fiber.current, file, buffer, 0, 1, 128)
+			result = io_pwrite(file, buffer, 0, 128, 1)
 			
 			expect(result).to be == -Errno::EINVAL::Errno
 		end

--- a/test/io/event/selector/select.rb
+++ b/test/io/event/selector/select.rb
@@ -78,7 +78,11 @@ describe IO::Event::Selector::Select do
 			
 			buffer = IO::Buffer.new(64)
 			
-			expect(selector.io_read(Fiber.current, input, buffer, 1)).to be == 0
+			if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+				expect(selector.io_read(Fiber.current, input, buffer, 0, 1)).to be == 0
+			else
+				expect(selector.io_read(Fiber.current, input, buffer, 1)).to be == 0
+			end
 		ensure
 			input&.close
 		end

--- a/test/io/event/selector/write_deadlock.rb
+++ b/test/io/event/selector/write_deadlock.rb
@@ -10,6 +10,8 @@ require "socket"
 WriteDeadlock = Sus::Shared("write deadlock") do
 	with "a pipe that fills up" do
 		it "should not deadlock when waiting for writable" do
+			skip "Single-transfer io_write returns EAGAIN directly" if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+			
 			# Skip on Windows which doesn't have the same socket behavior
 			skip_if_ruby_platform(/mswin|mingw|cygwin/)
 			


### PR DESCRIPTION
Ruby 4.1 updates the buffered IO scheduler hooks to interface version 4 as introduced by ruby/ruby#18483.

This change:

- uses `(offset, length)` for `io_read`, `io_write`, `io_pread`, and `io_pwrite` on interface version 4;
- performs one transfer of at most `length` bytes and returns short transfers directly;
- returns `-EAGAIN` from readiness-based selectors instead of waiting internally;
- submits one exact-length operation through io_uring; and
- preserves the existing minimum-progress behavior on earlier Ruby versions.

Native selectors select the implementation at compile time using `RUBY_FIBER_SCHEDULER_VERSION`. The pure Ruby Select implementation detects the corresponding IO::Buffer semantics with `IO::Buffer::VERSION >= 3`. Debug and benchmark wrappers forward the version-specific arguments without duplicating either interface.

Tests cover distinct offsets and lengths, short reads, zero-length operations, `EAGAIN`, and positional `pread`/`pwrite` while retaining coverage for the previous interface.

Validation:

- Ruby 4.0: 287 passed, 15 skipped, 908 assertions.
- Ruby 4.1 / IO::Buffer version 3: pure Ruby Select smoke coverage for bounded reads and writes, offsets, short transfers, and `EAGAIN`.
- Full RuboCop: 339 files, no offenses.
- CI: Ruby head, EPoll, io_uring, and ASAN pass.