### PR TITLE
Test stale wake-ups in threaded process waits

### DIFF
--- a/lib/io/event/selector.rb
+++ b/lib/io/event/selector.rb
@@ -43,7 +43,7 @@ module IO::Event
 		
 		# Wait for a process to change state, for the cases a selector cannot represent natively (e.g. `pid <= 0`: any child, or a process group). The native selectors integrate process waiting with the event loop using per-process primitives (`pidfd_open`, `EVFILT_PROC`) which can only refer to a single, specific process, and delegate here otherwise.
 		#
-		# The wait is performed on a separate thread, which has no fiber scheduler and therefore blocks. Joining it via `Thread#value` is fiber-scheduler aware, so the calling fiber yields to the event loop and the reactor keeps running other fibers.
+		# The wait is performed on a separate thread, which has no fiber scheduler and therefore blocks. Joining it is fiber-scheduler aware, so the calling fiber yields to the event loop and the reactor keeps running other fibers.
 		#
 		# @parameter pid [Integer] The process ID (or process group) to wait for.
 		# @parameter flags [Integer] Flags to pass to `Process::Status.wait`.
@@ -52,6 +52,9 @@ module IO::Event
 			thread = ::Thread.new do
 				::Process::Status.wait(pid, flags)
 			end
+			
+			# A stale scheduler wake-up can cause the join to return before the thread has finished, so keep waiting until the result is available:
+			thread.join while thread.alive?
 			
 			thread.value
 		ensure

--- a/lib/io/event/selector.rb
+++ b/lib/io/event/selector.rb
@@ -43,7 +43,7 @@ module IO::Event
 		
 		# Wait for a process to change state, for the cases a selector cannot represent natively (e.g. `pid <= 0`: any child, or a process group). The native selectors integrate process waiting with the event loop using per-process primitives (`pidfd_open`, `EVFILT_PROC`) which can only refer to a single, specific process, and delegate here otherwise.
 		#
-		# The wait is performed on a separate thread, which has no fiber scheduler and therefore blocks. Joining it is fiber-scheduler aware, so the calling fiber yields to the event loop and the reactor keeps running other fibers.
+		# The wait is performed on a separate thread, which has no fiber scheduler and therefore blocks. Joining it via `Thread#value` is fiber-scheduler aware, so the calling fiber yields to the event loop and the reactor keeps running other fibers.
 		#
 		# @parameter pid [Integer] The process ID (or process group) to wait for.
 		# @parameter flags [Integer] Flags to pass to `Process::Status.wait`.
@@ -52,9 +52,6 @@ module IO::Event
 			thread = ::Thread.new do
 				::Process::Status.wait(pid, flags)
 			end
-			
-			# On Ruby 3.4 and earlier, a stale scheduler wake-up can cause the join to return before the thread has finished, so keep waiting until the result is available:
-			thread.join while thread.alive?
 			
 			thread.value
 		ensure

--- a/lib/io/event/selector.rb
+++ b/lib/io/event/selector.rb
@@ -53,7 +53,7 @@ module IO::Event
 				::Process::Status.wait(pid, flags)
 			end
 			
-			# A stale scheduler wake-up can cause the join to return before the thread has finished, so keep waiting until the result is available:
+			# On Ruby 3.4 and earlier, a stale scheduler wake-up can cause the join to return before the thread has finished, so keep waiting until the result is available:
 			thread.join while thread.alive?
 			
 			thread.value

--- a/test/io/event/process.rb
+++ b/test/io/event/process.rb
@@ -35,6 +35,46 @@ ProcessWait = Sus::Shared("process wait") do
 		Fiber.set_scheduler(nil)
 	end
 	
+	it "ignores stale scheduler wake-ups while waiting in a worker thread" do
+		skip_if_ruby_platform(/mswin|mingw|cygwin/)
+		
+		input, output = IO.pipe
+		pid = Process.spawn(RbConfig.ruby, "-e", "STDIN.read", in: input)
+		input.close
+		input = nil
+		status = nil
+		
+		Fiber.set_scheduler(scheduler)
+		
+		Fiber.schedule do
+			# Simulate a deferred wake-up from a previous blocking operation:
+			scheduler.unblock(nil, Fiber.current)
+			
+			status = IO::Event::Selector.process_wait(pid, 0)
+		end
+		
+		Fiber.schedule do
+			# Release the child after the stale wake-up has been delivered:
+			sleep(0.01)
+			output.close
+			output = nil
+		end
+		
+		scheduler.run
+		
+		expect(status).to be(:success?)
+	ensure
+		input&.close
+		output&.close
+		
+		if pid
+			Process.kill(:KILL, pid) rescue nil
+			Process.wait(pid) rescue nil
+		end
+		
+		Fiber.set_scheduler(nil)
+	end
+	
 	it "can wait for all child processes" do
 		skip_if_ruby_platform(/mswin|mingw|cygwin/)
 		

--- a/test/io/event/process.rb
+++ b/test/io/event/process.rb
@@ -36,10 +36,14 @@ ProcessWait = Sus::Shared("process wait") do
 	end
 	
 	it "ignores stale scheduler wake-ups while waiting in a worker thread" do
+		# Pending backports of https://github.com/ruby/ruby/pull/13532:
+		# - Ruby 3.3: https://github.com/ruby/ruby/pull/18502
+		# - Ruby 3.4: https://github.com/ruby/ruby/pull/18503
+		skip_unless_minimum_ruby_version("4")
 		skip_if_ruby_platform(/mswin|mingw|cygwin/)
 		
 		input, output = IO.pipe
-		pid = Process.spawn(RbConfig.ruby, "-e", "STDIN.read", in: input)
+		pid = Process.spawn("cat", in: input, out: File::NULL)
 		input.close
 		input = nil
 		status = nil


### PR DESCRIPTION
## Summary

- Add regression coverage for stale scheduler wake-ups while waiting for a worker thread.
- Run the regression only on Ruby 4.0 and newer, where CRuby handles spurious Thread#join wake-ups correctly.
- Do not add an io-event runtime workaround.

Ruby 3.3 and 3.4 are skipped pending the upstream fix being backported:

- Upstream fix: ruby/ruby#13532
- Ruby 3.3 backport: ruby/ruby#18502
- Ruby 3.4 backport: ruby/ruby#18503

Discovered while validating socketry/async#469.

## Testing

- Ruby 3.4: 5 passed, 1 skipped (7 assertions)
- Ruby 4.0: 5 passed (8 assertions)
- RuboCop: no offenses