### PR TITLE
Fix io_uring scheduler v4 compilation

### DIFF
--- a/bake.rb
+++ b/bake.rb
@@ -8,8 +8,8 @@ def build
 	ext_path = File.expand_path("ext", __dir__)
 	
 	Dir.chdir(ext_path) do
-		system("ruby ./extconf.rb")
-		system("make")
+		system("ruby", "./extconf.rb", exception: true)
+		system("make", exception: true)
 	end
 end
 

--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -1034,7 +1034,6 @@ VALUE IO_Event_Selector_URing_io_read(VALUE self, VALUE fiber, VALUE io, VALUE b
 	} else if (offset == size) {
 		return rb_fiber_scheduler_io_result(0, 0);
 	}
-#endif
 	
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	off_t from = io_seekable(descriptor);
@@ -1122,7 +1121,6 @@ VALUE IO_Event_Selector_URing_io_pread(VALUE self, VALUE fiber, VALUE io, VALUE 
 	} else if (offset == size) {
 		return rb_fiber_scheduler_io_result(0, 0);
 	}
-#endif
 	off_t from = NUM2OFFT(_from);
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	size_t maximum_size = size - offset;
@@ -1307,7 +1305,6 @@ VALUE IO_Event_Selector_URing_io_write(VALUE self, VALUE fiber, VALUE io, VALUE 
 	} else if (offset == size) {
 		return rb_fiber_scheduler_io_result(0, 0);
 	}
-#endif
 	
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	off_t from = io_seekable(descriptor);
@@ -1385,7 +1382,6 @@ VALUE IO_Event_Selector_URing_io_pwrite(VALUE self, VALUE fiber, VALUE io, VALUE
 	} else if (offset == size) {
 		return rb_fiber_scheduler_io_result(0, 0);
 	}
-#endif
 	off_t from = NUM2OFFT(_from);
 	int descriptor = IO_Event_Selector_io_descriptor(io);
 	size_t maximum_size = size - offset;


### PR DESCRIPTION
## Summary

- Keep the legacy `io_read`, `io_pread`, `io_write`, and `io_pwrite` implementations entirely within their scheduler-version conditional branches.
- Make native extension build failures propagate from the Bake build task.

## Background

The scheduler interface v4 branches returned through the locked-buffer callbacks, but four premature `#endif` directives also compiled the legacy implementations without their local variables. This broke `io-event` 1.20.0 on Linux with liburing under Ruby 4.0 and Ruby head.

The existing io-event CI did encounter these compiler errors, but `bake.rb#build` ignored the failed `system` results. Tests then continued with the pure-Ruby selector, allowing the jobs to report success. Raising on failed build commands ensures future native compilation failures fail CI.

This was observed in socketry/async#469.

## Testing

- Ruby 4.0.5 on macOS: 289 passed, 15 skipped (910 assertions).
- Linux Ruby 4.0/head with liburing will be exercised by CI.