### PR TITLE
Handle interrupted io_uring process waits

### DIFF
--- a/ext/io/event/selector/uring.c
+++ b/ext/io/event/selector/uring.c
@@ -648,10 +648,18 @@ static
 VALUE process_wait_transfer(VALUE _arguments) {
 	struct process_wait_arguments *arguments = (struct process_wait_arguments *)_arguments;
 	
+#ifdef IO_EVENT_SELECTOR_URING_USE_WAITID
 	IO_Event_Selector_loop_yield(&arguments->selector->backend);
 	
-#ifdef IO_EVENT_SELECTOR_URING_USE_WAITID
+	if (arguments->waiting->completion) {
+		// The kernel may still write to siginfo or reap the child. Keep the C frame alive until the original operation completes, then distinguish cancellation from process completion:
+		IO_Event_Selector_URing_Waiting_cancel_and_wait(arguments->selector, arguments->waiting);
+	}
+	
 	int32_t result = arguments->waiting->result;
+	if (result == -ECANCELED) {
+		return Qfalse;
+	}
 	
 	if (DEBUG) fprintf(stderr, "waitid result=%d pid=%d code=%d status=%d\n", result, arguments->siginfo.si_pid, arguments->siginfo.si_code, arguments->siginfo.si_status);
 	
@@ -672,6 +680,8 @@ VALUE process_wait_transfer(VALUE _arguments) {
 	return IO_Event_Selector_process_status_reap(arguments->siginfo.si_pid, arguments->flags);
 #endif
 #else
+	IO_Event_Selector_loop_yield(&arguments->selector->backend);
+	
 	if (arguments->waiting->result) {
 		return IO_Event_Selector_process_status_reap(arguments->pid, arguments->flags);
 	} else {
@@ -684,15 +694,17 @@ static
 VALUE process_wait_ensure(VALUE _arguments) {
 	struct process_wait_arguments *arguments = (struct process_wait_arguments *)_arguments;
 	
+#ifdef IO_EVENT_SELECTOR_URING_USE_WAITID
+	// `waitid` may write to stack-backed siginfo while cancellation is pending:
+	IO_Event_Selector_URing_Waiting_cancel_and_wait(arguments->selector, arguments->waiting);
+#else
 	if (arguments->waiting->completion) {
 		IO_Event_Selector_URing_Completion_cancel_async(arguments->selector, arguments->waiting->completion);
 	}
 	
-#ifndef IO_EVENT_SELECTOR_URING_USE_WAITID
 	close(arguments->descriptor);
-#endif
-	
 	IO_Event_Selector_URing_Waiting_cancel(arguments->waiting);
+#endif
 	
 	return Qnil;
 }

--- a/test/io/event/selector.rb
+++ b/test/io/event/selector.rb
@@ -657,6 +657,39 @@ Selector = Sus::Shared("a selector") do
 	end
 	
 	with "#process_wait" do
+		it "returns false when interrupted before the process terminates" do
+			unless selector.method(:process_wait).source_location.nil?
+				skip "A native selector is required!"
+			end
+			
+			input, output = IO.pipe
+			pid = Process.spawn("cat", in: input, out: File::NULL)
+			input.close
+			input = nil
+			result = :unset
+			
+			fiber = Fiber.new do
+				result = selector.process_wait(Fiber.current, pid, 0)
+			end
+			
+			fiber.transfer
+			fiber.transfer
+			
+			while fiber.alive?
+				selector.select(1)
+			end
+			
+			expect(result).to be == false
+		ensure
+			input&.close
+			output&.close
+			
+			if pid
+				Process.kill(:KILL, pid) rescue nil
+				Process.wait(pid) rescue nil
+			end
+		end
+		
 		it "can wait for a process which has terminated already" do
 			result = nil
 			events = []


### PR DESCRIPTION
## Summary

- preserve the native selector contract of returning `false` when `process_wait` is resumed before process completion
- safely cancel and drain io_uring `waitid` operations before stack-backed `siginfo` goes out of scope
- return `false` when cancellation wins, or preserve the real process status when `waitid` wins the cancellation race
- add shared coverage for interrupted native process waits

KQueue, EPoll, and legacy pidfd-based io_uring waits already return `false` on a normal interruption. This makes modern io_uring `waitid` consistent without imposing retry policy on io-event; higher-level schedulers such as Async can decide whether to retry.

## Testing

- `BUNDLE_GEMFILE=gems.rb bundle exec bake build`
- `BUNDLE_GEMFILE=gems.rb bundle exec bake test` (292 passed, 17 skipped; 911 assertions)